### PR TITLE
Round to n digits

### DIFF
--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/round.hpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015 - J.T. Lapreste
 //         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //
@@ -57,12 +58,46 @@ namespace boost { namespace simd { namespace tag
     aways from 0 means that half integer values are rounded to the nearest
     integer of greatest absolute value
 
-    @param  a0
+    @param  x value to be rounded
 
     @return      a value of the same type as the input.
 
   **/
   BOOST_DISPATCH_FUNCTION_IMPLEMENTATION(tag::round_, round, 1)
+  /*!
+    round(x,n) rounds aways from 0 to n digits:
+
+    @par semantic:
+    For any given value @c x of type @c T and integer n :
+
+    @code
+    T r = round(x, n);
+    @endcode
+
+    is equivalent to
+
+    @code
+    T r = round(x*exp10(n)*exp10(-n));
+    @endcode
+
+    @par Note:
+
+    n > 0: round to n digits to the right of the decimal point.
+
+    n = 0: round to the nearest integer.
+
+    n < 0: round to n digits to the left of the decimal point.
+
+    aways from 0 means that half integer values are rounded to the nearest
+    integer of greatest absolute value
+
+    @param  x value to be rounded
+    @param  n number of digits
+
+    @return      a value of the same type as the input.
+
+  **/
+  BOOST_DISPATCH_FUNCTION_IMPLEMENTATION(tag::round_, round, 2)
 } }
 
 #endif

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/round.hpp
@@ -1,7 +1,7 @@
 //==============================================================================
 //         Copyright 2015 - J.T. Lapreste
 //         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
-//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2009 - 2015   LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/round.hpp
@@ -1,7 +1,7 @@
 //==============================================================================
 //         Copyright 2015 - J.T. Lapreste
 //         Copyright 2003 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
-//         Copyright 2009 - 2011 LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2009 - 2015 LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/round.hpp
@@ -13,6 +13,7 @@
 #include <boost/simd/arithmetic/functions/round.hpp>
 #include <boost/simd/include/functions/scalar/abs.hpp>
 #include <boost/simd/include/functions/scalar/copysign.hpp>
+#include <boost/simd/include/functions/scalar/is_ltz.hpp>
 #include <boost/simd/include/functions/scalar/seldec.hpp>
 #include <boost/simd/include/functions/scalar/ceil.hpp>
 #include <boost/simd/include/functions/scalar/tenpower.hpp>
@@ -89,7 +90,8 @@ namespace boost { namespace simd { namespace ext
     {
       typedef typename  dispatch::meta::as_integer<A0>::type itype;
       A0 fac = tenpower(itype(a1));
-      return round(a0*fac)/fac;
+      A0 tmp = round(a0*fac)/fac;
+      return is_ltz(a1) ? round(tmp) : tmp;
     }
   };
 

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/round.hpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015 - J.T. Lapreste
 //         Copyright 2003 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2011 LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //
@@ -14,6 +15,7 @@
 #include <boost/simd/include/functions/scalar/copysign.hpp>
 #include <boost/simd/include/functions/scalar/seldec.hpp>
 #include <boost/simd/include/functions/scalar/ceil.hpp>
+#include <boost/simd/include/functions/scalar/tenpower.hpp>
 #include <boost/simd/include/constants/maxflint.hpp>
 #include <boost/simd/include/constants/half.hpp>
 #include <boost/simd/sdk/math.hpp>
@@ -47,7 +49,7 @@ namespace boost { namespace simd { namespace ext
 #else
       const result_type v = simd::abs(a0);
       if (!(v <=  Maxflint<result_type>()))
-          return a0;
+        return a0;
       result_type c =  boost::simd::ceil(v);
       return copysign(seldec(c-Half<result_type>() > v, c), a0);
 #endif
@@ -66,14 +68,31 @@ namespace boost { namespace simd { namespace ext
 #ifdef BOOST_SIMD_HAS_ROUND
       return ::round(a0);
 #else
-       const result_type v = simd::abs(a0);
-       if (!(v <=  Maxflint<result_type>()))
-           return a0;
+      const result_type v = simd::abs(a0);
+      if (!(v <=  Maxflint<result_type>()))
+        return a0;
       result_type c =  boost::simd::ceil(v);
       return copysign(seldec(c-Half<result_type>() > v, c), a0);
 #endif
-     }
+    }
   };
+
+  BOOST_DISPATCH_IMPLEMENT          ( round_, tag::cpu_
+                                    , (A0)(A1)
+                                    , (scalar_< floating_<A0> >)
+                                      (scalar_< integer_<A1> >)
+                                    )
+  {
+    typedef A0 result_type;
+
+    BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
+    {
+      typedef typename  dispatch::meta::as_integer<A0>::type itype;
+      A0 fac = tenpower(itype(a1));
+      return round(a0*fac)/fac;
+    }
+  };
+
 } } }
 
 #endif

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/tenpower.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/tenpower.hpp
@@ -1,0 +1,69 @@
+//==============================================================================
+//         Copyright 2015 - J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_SCALAR_TENPOWER_HPP_INCLUDED
+#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_SCALAR_TENPOWER_HPP_INCLUDED
+
+#include <boost/simd/arithmetic/functions/tenpower.hpp>
+#include <boost/dispatch/meta/as_floating.hpp>
+#include <boost/simd/include/constants/one.hpp>
+#include <boost/simd/include/constants/ten.hpp>
+#include <boost/simd/include/functions/abs.hpp>
+#include <boost/simd/include/functions/sqr.hpp>
+#include <boost/simd/include/functions/is_odd.hpp>
+#include <boost/simd/include/functions/rec.hpp>
+#include <boost/dispatch/attributes.hpp>
+#include <nt2/table.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( tenpower_, tag::cpu_
+                            , (A0)
+                            , (scalar_< int_<A0> >)
+                            )
+  {
+    typedef  typename dispatch::meta::as_floating<A0>::type result_type;
+
+    BOOST_FORCEINLINE result_type operator()(A0 exp) const
+    {
+      result_type result = One<result_type>();
+      result_type base = Ten<result_type>();
+      bool neg = exp < 0;
+      exp =  boost::simd::abs(exp);
+      while(exp)
+      {
+        if (is_odd(exp)) result *= base;
+        exp >>= 1;
+        base = sqr(base);
+      }
+      return neg ? rec(result) : result;
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( tenpower_, tag::cpu_
+                            , (A0)
+                            , (scalar_< uint_<A0> >)
+                            )
+  {
+    typedef  typename dispatch::meta::as_floating<A0>::type result_type;
+
+    BOOST_FORCEINLINE result_type operator()(A0 exp) const
+    {
+      result_type result = One<result_type>();
+      result_type base = Ten<result_type>();
+      while(exp)
+      {
+        if (is_odd(exp)) result *= base;
+        exp >>= 1;
+        base = sqr(base);
+      }
+      return result;
+    }
+  };
+} } }
+
+#endif

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/tenpower.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/scalar/tenpower.hpp
@@ -14,10 +14,10 @@
 #include <boost/simd/include/constants/ten.hpp>
 #include <boost/simd/include/functions/abs.hpp>
 #include <boost/simd/include/functions/sqr.hpp>
-#include <boost/simd/include/functions/is_odd.hpp>
-#include <boost/simd/include/functions/rec.hpp>
+#include <boost/simd/include/functions/scalar/is_odd.hpp>
+#include <boost/simd/include/functions/scalar/rec.hpp>
 #include <boost/dispatch/attributes.hpp>
-#include <nt2/table.hpp>
+
 
 namespace boost { namespace simd { namespace ext
 {

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
@@ -2,7 +2,7 @@
 //         Copyright 2015 - J.T. Lapreste
 //         Copyright 2003 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2011 LRI    UMR 8623 CNRS/Univ Paris Sud XI
-//         Copyright 2012 - 2014 MetaScale SAS
+//         Copyright 2012 - 2015 MetaScale SAS
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at
@@ -17,8 +17,6 @@
 #include <boost/simd/include/functions/simd/seldec.hpp>
 #include <boost/simd/include/functions/simd/is_greater.hpp>
 #include <boost/simd/include/functions/simd/abs.hpp>
-#include <boost/simd/include/functions/simd/frexp.hpp>
-#include <boost/simd/include/functions/simd/ldexp.hpp>
 #include <boost/simd/include/functions/simd/minus.hpp>
 #include <boost/simd/include/functions/simd/ceil.hpp>
 #include <boost/simd/include/constants/half.hpp>
@@ -66,25 +64,6 @@ namespace boost { namespace simd { namespace ext
       return round(a0*fac)/fac;
     }
   };
-
- //  BOOST_DISPATCH_IMPLEMENT          ( round_, boost::simd::tag::simd_
-//                                     , (A0)(X)(A1)(A2)
-//                                     , ((simd_< floating_<A0>,X>))
-//                                       ((simd_< integer_<A1>,X>))
-//                                       ((simd_< unspecified_<A2>,X>))
-//                                     )
-//   {
-//     typedef A0 result_type;
-
-//     BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
-//     {
-//       A0 a0n;
-//       iA0 n;
-//       frexp(a0, a0n, n);
-//       A0 fac = tenpower(a1);
-//       return ldexp(round(a0*fac)/fac, n);
-//     }
-//   };
 
 } } }
 

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
@@ -18,6 +18,8 @@
 #include <boost/simd/include/functions/simd/is_greater.hpp>
 #include <boost/simd/include/functions/simd/abs.hpp>
 #include <boost/simd/include/functions/simd/minus.hpp>
+#include <boost/simd/include/functions/simd/multiplies.hpp>
+#include <boost/simd/include/functions/simd/mdivides.hpp>
 #include <boost/simd/include/functions/simd/ceil.hpp>
 #include <boost/simd/include/constants/half.hpp>
 #include <boost/dispatch/attributes.hpp>

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015 - J.T. Lapreste
 //         Copyright 2003 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2011 LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //         Copyright 2012 - 2014 MetaScale SAS
@@ -11,6 +12,7 @@
 #define BOOST_SIMD_ARITHMETIC_FUNCTIONS_SIMD_COMMON_ROUND_HPP_INCLUDED
 
 #include <boost/simd/arithmetic/functions/round.hpp>
+#include <boost/simd/include/functions/simd/tenpower.hpp>
 #include <boost/simd/include/functions/simd/copysign.hpp>
 #include <boost/simd/include/functions/simd/seldec.hpp>
 #include <boost/simd/include/functions/simd/is_greater.hpp>
@@ -47,6 +49,23 @@ namespace boost { namespace simd { namespace ext
       return copysign(seldec(gt(c-Half<result_type>(), absa0), c), a0);
     }
   };
+
+  BOOST_DISPATCH_IMPLEMENT          ( round_, boost::simd::tag::simd_
+                                    , (A0)(X)(A1)
+                                    , ((simd_< floating_<A0>,X>))
+                                      ((simd_< integer_<A1>,X>))
+                                    )
+  {
+    typedef A0 result_type;
+
+    BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
+    {
+      A0 fac = tenpower(a1);
+      return round(a0*fac)/fac;
+    }
+  };
+
+
 } } }
 
 #endif

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
@@ -17,6 +17,8 @@
 #include <boost/simd/include/functions/simd/seldec.hpp>
 #include <boost/simd/include/functions/simd/is_greater.hpp>
 #include <boost/simd/include/functions/simd/abs.hpp>
+#include <boost/simd/include/functions/simd/frexp.hpp>
+#include <boost/simd/include/functions/simd/ldexp.hpp>
 #include <boost/simd/include/functions/simd/minus.hpp>
 #include <boost/simd/include/functions/simd/ceil.hpp>
 #include <boost/simd/include/constants/half.hpp>
@@ -65,6 +67,24 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
+ //  BOOST_DISPATCH_IMPLEMENT          ( round_, boost::simd::tag::simd_
+//                                     , (A0)(X)(A1)(A2)
+//                                     , ((simd_< floating_<A0>,X>))
+//                                       ((simd_< integer_<A1>,X>))
+//                                       ((simd_< unspecified_<A2>,X>))
+//                                     )
+//   {
+//     typedef A0 result_type;
+
+//     BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
+//     {
+//       A0 a0n;
+//       iA0 n;
+//       frexp(a0, a0n, n);
+//       A0 fac = tenpower(a1);
+//       return ldexp(round(a0*fac)/fac, n);
+//     }
+//   };
 
 } } }
 

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/round.hpp
@@ -19,7 +19,7 @@
 #include <boost/simd/include/functions/simd/abs.hpp>
 #include <boost/simd/include/functions/simd/minus.hpp>
 #include <boost/simd/include/functions/simd/multiplies.hpp>
-#include <boost/simd/include/functions/simd/mdivides.hpp>
+#include <boost/simd/include/functions/simd/divides.hpp>
 #include <boost/simd/include/functions/simd/ceil.hpp>
 #include <boost/simd/include/constants/half.hpp>
 #include <boost/dispatch/attributes.hpp>

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/tenpower.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/tenpower.hpp
@@ -1,0 +1,73 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_SIMD_COMMON_TENPOWER_HPP_INCLUDED
+#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_SIMD_COMMON_TENPOWER_HPP_INCLUDED
+
+#include <boost/simd/arithmetic/functions/tenpower.hpp>
+#include <boost/simd/include/functions/simd/abs.hpp>
+#include <boost/simd/include/functions/simd/if_else.hpp>
+#include <boost/simd/include/functions/simd/is_odd.hpp>
+#include <boost/simd/include/functions/simd/is_ltz.hpp>
+#include <boost/simd/include/functions/simd/shift_right.hpp>
+#include <boost/simd/include/functions/simd/multiplies.hpp>
+#include <boost/simd/include/functions/simd/any.hpp>
+#include <boost/simd/include/functions/simd/abs.hpp>
+#include <boost/simd/include/functions/simd/sqr.hpp>
+#include <boost/simd/include/constants/one.hpp>
+#include <boost/simd/include/constants/ten.hpp>
+#include <boost/dispatch/meta/as_floating.hpp>
+#include <boost/dispatch/attributes.hpp>
+
+namespace boost { namespace simd { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT( tenpower_, tag::cpu_
+                          , (A0)(X)
+                          , ((simd_<int_<A0>,X>))
+                          )
+  {
+    typedef typename dispatch::meta::as_floating<A0>::type result_type;
+    BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(1)
+    {
+      result_type result = One<result_type>();
+      result_type base = Ten<result_type>();
+      A0 exp = boost::simd::abs(a0);
+      while(any(exp))
+      {
+        result *= if_else(is_odd(exp), base, One<result_type>());
+        exp >>= 1;
+        base = sqr(base);
+      }
+      return if_else(is_ltz(a0), rec(result), result);
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT( tenpower_, tag::cpu_
+                          , (A0)(X)
+                          , ((simd_<uint_<A0>,X>))
+                          )
+  {
+    typedef typename dispatch::meta::as_floating<A0>::type result_type;
+    BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(1)
+    {
+      result_type result = One<result_type>();
+      result_type base = Ten<result_type>();
+      A0 exp = a0;
+      while(any(exp))
+      {
+        result *= if_else(is_odd(exp), base, One<result_type>());
+        exp >>= 1;
+        base = sqr(base);
+      }
+      return result;
+    }
+  };
+
+} } }
+
+
+#endif

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/tenpower.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/simd/common/tenpower.hpp
@@ -22,12 +22,16 @@
 #include <boost/simd/include/constants/ten.hpp>
 #include <boost/dispatch/meta/as_floating.hpp>
 #include <boost/dispatch/attributes.hpp>
+#include <boost/mpl/equal_to.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
-  BOOST_DISPATCH_IMPLEMENT( tenpower_, tag::cpu_
-                          , (A0)(X)
-                          , ((simd_<int_<A0>,X>))
+  BOOST_DISPATCH_IMPLEMENT_IF( tenpower_, tag::cpu_
+                             , (A0)(X)
+                             , (boost::mpl::equal_to < boost::simd::meta::cardinal_of<A0>
+                                , boost::simd::meta::cardinal_of<typename dispatch::meta::as_floating<A0>::type>
+                                >)
+                             , ((simd_<int_<A0>,X>))
                           )
   {
     typedef typename dispatch::meta::as_floating<A0>::type result_type;
@@ -46,9 +50,12 @@ namespace boost { namespace simd { namespace ext
     }
   };
 
-  BOOST_DISPATCH_IMPLEMENT( tenpower_, tag::cpu_
-                          , (A0)(X)
-                          , ((simd_<uint_<A0>,X>))
+  BOOST_DISPATCH_IMPLEMENT_IF( tenpower_, tag::cpu_
+                             , (A0)(X)
+                             , (boost::mpl::equal_to < boost::simd::meta::cardinal_of<A0>
+                                , boost::simd::meta::cardinal_of<typename dispatch::meta::as_floating<A0>::type>
+                                >)
+                             , ((simd_<uint_<A0>,X>))
                           )
   {
     typedef typename dispatch::meta::as_floating<A0>::type result_type;
@@ -66,7 +73,6 @@ namespace boost { namespace simd { namespace ext
       return result;
     }
   };
-
 } } }
 
 

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/tenpower.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/tenpower.hpp
@@ -1,0 +1,70 @@
+//==============================================================================
+//          Copyright 2015 - J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_TENPOWER_HPP_INCLUDED
+#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_TENPOWER_HPP_INCLUDED
+#include <boost/simd/include/functor.hpp>
+#include <boost/dispatch/include/functor.hpp>
+
+namespace boost { namespace simd { namespace tag
+  {
+    /*!
+      @brief  tenpower generic tag
+
+      Represents the tenpower function in generic contexts.
+
+      @par Models:
+      Hierarchy
+    **/
+    struct tenpower_ : ext::elementwise_<tenpower_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::elementwise_<tenpower_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_tenpower_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::tenpower_, Site> dispatching_tenpower_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::tenpower_, Site>();
+    }
+    template<class... Args>
+    struct impl_tenpower_;
+  }
+
+  /*!
+    Returns \f$10^n\f$ in the floating type  corresponding to A0
+
+    @par semantic:
+    For any given value n  of integral type @c I, and T of type as_floating<I>::type
+
+    @code
+    T r = tenpower(n);
+    @endcode
+
+    code is similar to:
+
+    @code
+    T r = exp10(T(n));
+    @endcode
+
+    @par Note:
+
+    This function is not defined for floating entries
+
+    @param  n
+
+    @return a value of the floating associated type.
+
+  **/
+  BOOST_DISPATCH_FUNCTION_IMPLEMENTATION(tag::tenpower_, tenpower, 1)
+} }
+#endif

--- a/modules/boost/simd/base/include/boost/simd/arithmetic/functions/tenpower.hpp
+++ b/modules/boost/simd/base/include/boost/simd/arithmetic/functions/tenpower.hpp
@@ -41,7 +41,7 @@ namespace boost { namespace simd { namespace tag
   }
 
   /*!
-    Returns \f$10^n\f$ in the floating type  corresponding to A0
+    @brief Returns \f$10^n\f$ in the floating type  corresponding to A0
 
     @par semantic:
     For any given value n  of integral type @c I, and T of type as_floating<I>::type

--- a/modules/boost/simd/base/unit/arithmetic/scalar/CMakeLists.txt
+++ b/modules/boost/simd/base/unit/arithmetic/scalar/CMakeLists.txt
@@ -73,6 +73,7 @@ SET( SOURCES
   sqrs.cpp
   sqrt.cpp
   subs.cpp
+  tenpower.cpp
   tofloat.cpp
   toint.cpp
   toints.cpp

--- a/modules/boost/simd/base/unit/arithmetic/scalar/round.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/scalar/round.cpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015          J.T. Lapreste
 //         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //

--- a/modules/boost/simd/base/unit/arithmetic/scalar/round.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/scalar/round.cpp
@@ -9,6 +9,7 @@
 #include <boost/simd/arithmetic/include/functions/round.hpp>
 #include <boost/dispatch/functor/meta/call.hpp>
 #include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
 #include <nt2/sdk/unit/tests/type_expr.hpp>
 #include <nt2/sdk/unit/module.hpp>
 #include <boost/simd/include/constants/zero.hpp>
@@ -67,6 +68,50 @@ NT2_TEST_CASE_TPL ( round_real,  BOOST_SIMD_REAL_TYPES)
   T z = boost::simd::Maxflint < T>()/T(2)+T(1);
   NT2_TEST_EQUAL(round(z), z);
 
+} // end of test for floating_
+
+NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
+{
+
+  using boost::simd::round;
+  using boost::simd::tag::round_;
+  using boost::simd::next;
+  using boost::simd::prev;
+  typedef typename boost::dispatch::meta::call<round_(T)>::type r_t;
+  typedef T wished_r_t;
+
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS( r_t, wished_r_t );
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(round(boost::simd::Inf<T>(), 2), boost::simd::Inf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Minf<T>(), 2), boost::simd::Minf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Nan<T>(), 2), boost::simd::Nan<r_t>());
+#endif
+  NT2_TEST_EQUAL(round(boost::simd::Mhalf<T>(), 2), boost::simd::Mhalf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Mone<T>(), 2), boost::simd::Mone<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::One<T>(), 2), boost::simd::One<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Zero<T>(), 2), boost::simd::Zero<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<T>()-boost::simd::Half<T>(), 2),boost::simd::Maxflint<T>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<T>(), 2),boost::simd::Maxflint<T>());
+  NT2_TEST_EQUAL(round(T(1.44), 1), T(1.4));
+  NT2_TEST_EQUAL(round(T(1.45), 1), T(1.5));
+  NT2_TEST_EQUAL(round(T(1.46), 1), T(1.5));
+  NT2_TEST_EQUAL(round(T(2.45), 1), T(2.5));
+  NT2_TEST_EQUAL(round(T(-1.44), 1), T(-1.4));
+  NT2_TEST_EQUAL(round(T(-1.45), 1), T(-1.5));
+  NT2_TEST_EQUAL(round(T(-1.46), 1), T(-1.5));
+  NT2_TEST_EQUAL(round(T(-2.45), 1), T(-2.5));
+  NT2_TEST_ULP_EQUAL(round(T(145), -2), T(100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(150), -2), T(200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(156), -2), T(200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(250), -2), T(300), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(-145), -2), T(-100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(-155), -2), T(-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(-156), -2), T(-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(T(-255), -2), T(-300), 0.5);
 } // end of test for floating_
 
 NT2_TEST_CASE_TPL ( round_unsigned_int__1_0,  BOOST_SIMD_UNSIGNED_TYPES)

--- a/modules/boost/simd/base/unit/arithmetic/scalar/round.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/scalar/round.cpp
@@ -114,6 +114,8 @@ NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
   NT2_TEST_ULP_EQUAL(round(T(-255), -2), T(-300), 0.5);
 } // end of test for floating_
 
+
+
 NT2_TEST_CASE_TPL ( round_unsigned_int__1_0,  BOOST_SIMD_UNSIGNED_TYPES)
 {
 

--- a/modules/boost/simd/base/unit/arithmetic/scalar/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/scalar/tenpower.cpp
@@ -1,6 +1,5 @@
 //==============================================================================
-//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
-//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2015 J.T. Lapreste
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at

--- a/modules/boost/simd/base/unit/arithmetic/scalar/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/scalar/tenpower.cpp
@@ -1,0 +1,54 @@
+//==============================================================================
+//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <boost/simd/arithmetic/include/functions/tenpower.hpp>
+#include <boost/dispatch/functor/meta/call.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/include/constants/one.hpp>
+#include <boost/simd/include/constants/oneo_10.hpp>
+#include <boost/simd/include/constants/zero.hpp>
+#include <boost/simd/include/constants/mone.hpp>
+#include <boost/simd/include/constants/hundred.hpp>
+#include <boost/simd/include/functions/sqr.hpp>
+
+
+NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_UNSIGNED_TYPES)
+{
+
+  using boost::simd::tenpower;
+  using boost::simd::tag::tenpower_;
+  typedef typename boost::dispatch::meta::call<tenpower_(T)>::type r_t;
+  typedef typename boost::dispatch::meta::as_floating<T>::type  wished_r_t;
+
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+  // specific values tests
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::One<T>()), boost::simd::Ten<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Two<T>()), boost::simd::Hundred<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<T>()), boost::simd::One<r_t>(), 0.5);
+} // end of test for unsigned_int_
+
+NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_INTEGRAL_SIGNED_TYPES)
+{
+
+  using boost::simd::tenpower;
+  using boost::simd::tag::tenpower_;
+  typedef typename boost::dispatch::meta::call<tenpower_(T)>::type r_t;
+  typedef typename boost::dispatch::meta::as_floating<T>::type  wished_r_t;
+
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+  // specific values tests
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Mone<T>()), boost::simd::Oneo_10<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::One<T>()), boost::simd::Ten<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Two<T>()), boost::simd::Hundred<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Mtwo<T>()), boost::simd::sqr(boost::simd::Oneo_10<r_t>()), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<T>()), boost::simd::One<r_t>(), 0.5);
+} // end of test for signed_int_

--- a/modules/boost/simd/base/unit/arithmetic/simd/CMakeLists.txt
+++ b/modules/boost/simd/base/unit/arithmetic/simd/CMakeLists.txt
@@ -73,6 +73,7 @@ SET( SOURCES
   sqrs.cpp
   sqrt.cpp
   subs.cpp
+  tenpower.cpp
   tofloat.cpp
   toint.cpp
   toints.cpp

--- a/modules/boost/simd/base/unit/arithmetic/simd/round.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/round.cpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015          J.T. Lapreste
 //         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //

--- a/modules/boost/simd/base/unit/arithmetic/simd/round.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/round.cpp
@@ -33,7 +33,7 @@
 #include <boost/simd/include/functions/plus.hpp>
 #include <boost/simd/include/functions/splat.hpp>
 
-NT2_TEST_CASE_TPL ( round_real,  BOOST_SIMD_SIMD_REAL_TYPES)
+NT2_TEST_CASE_TPL ( round_real, BOOST_SIMD_SIMD_REAL_TYPES)
 {
   using boost::simd::round;
   using boost::simd::tag::round_;
@@ -107,6 +107,48 @@ NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_SIMD_REAL_TYPES)
   NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-155), -2), boost::simd::splat<vT>(-200), 0.5);
   NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-156), -2), boost::simd::splat<vT>(-200), 0.5);
   NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-255), -2), boost::simd::splat<vT>(-300), 0.5);
+} // end of test for floating_
+
+NT2_TEST_CASE_TPL ( round_real2b,  BOOST_SIMD_SIMD_REAL_TYPES)
+{
+
+  using boost::simd::round;
+  using boost::simd::tag::round_;
+  using boost::simd::native;
+  using boost::simd::splat;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+  typedef typename boost::dispatch::meta::as_integer<vT>::type viT;
+  typedef typename boost::dispatch::meta::call<round_(vT)>::type r_t;
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(round(boost::simd::Inf<vT>(), splat<viT>(2)), boost::simd::Inf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Minf<vT>(), splat<viT>(2)), boost::simd::Minf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Nan<vT>(), splat<viT>(2)), boost::simd::Nan<r_t>());
+#endif
+  NT2_TEST_EQUAL(round(boost::simd::Mhalf<vT>(), splat<viT>(2)), boost::simd::Mhalf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Mone<vT>(), splat<viT>(2)), boost::simd::Mone<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::One<vT>(), splat<viT>(2)), boost::simd::One<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Zero<vT>(), splat<viT>(2)), boost::simd::Zero<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vT>()-boost::simd::Half<vT>(), splat<viT>(2)),boost::simd::Maxflint<vT>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vT>(), splat<viT>(2)),boost::simd::Maxflint<vT>());
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(1.44), splat<viT>(1)), boost::simd::splat<vT>(1.4));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(1.45), splat<viT>(1)), boost::simd::splat<vT>(1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(1.46), splat<viT>(1)), boost::simd::splat<vT>(1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(2.45), splat<viT>(1)), boost::simd::splat<vT>(2.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-1.44), splat<viT>(1)), boost::simd::splat<vT>(-1.4));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-1.45), splat<viT>(1)), boost::simd::splat<vT>(-1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-1.46), splat<viT>(1)), boost::simd::splat<vT>(-1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-2.45), splat<viT>(1)), boost::simd::splat<vT>(-2.5));
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(145), splat<viT>(-2)), boost::simd::splat<vT>(100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(150), splat<viT>(-2)), boost::simd::splat<vT>(200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(156), splat<viT>(-2)), boost::simd::splat<vT>(200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(250), splat<viT>(-2)), boost::simd::splat<vT>(300), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-145), splat<viT>(-2)), boost::simd::splat<vT>(-100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-155), splat<viT>(-2)), boost::simd::splat<vT>(-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-156), splat<viT>(-2)), boost::simd::splat<vT>(-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-255), splat<viT>(-2)), boost::simd::splat<vT>(-300), 0.5);
 } // end of test for floating_
 
 NT2_TEST_CASE_TPL ( round_unsigned_int,  BOOST_SIMD_SIMD_UNSIGNED_TYPES)

--- a/modules/boost/simd/base/unit/arithmetic/simd/round.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/round.cpp
@@ -10,6 +10,7 @@
 #include <boost/simd/sdk/simd/native.hpp>
 #include <boost/dispatch/functor/meta/call.hpp>
 #include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
 #include <nt2/sdk/unit/module.hpp>
 #include <boost/simd/include/constants/zero.hpp>
 #include <boost/simd/include/constants/one.hpp>
@@ -29,6 +30,7 @@
 #include <boost/simd/include/functions/splat.hpp>
 #include <boost/simd/include/functions/multiplies.hpp>
 #include <boost/simd/include/functions/plus.hpp>
+#include <boost/simd/include/functions/splat.hpp>
 
 NT2_TEST_CASE_TPL ( round_real,  BOOST_SIMD_SIMD_REAL_TYPES)
 {
@@ -64,6 +66,46 @@ NT2_TEST_CASE_TPL ( round_real,  BOOST_SIMD_SIMD_REAL_TYPES)
   NT2_TEST_EQUAL(round(next(boost::simd::Half<vT>())),  boost::simd::One <vT>());
   vT z = boost::simd::Maxflint <vT>()*boost::simd::Half<vT>()+boost::simd::One<vT>();
   NT2_TEST_EQUAL(round(z), z);
+} // end of test for floating_
+
+NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_SIMD_REAL_TYPES)
+{
+
+  using boost::simd::round;
+  using boost::simd::tag::round_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+  typedef typename boost::dispatch::meta::call<round_(vT)>::type r_t;
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(round(boost::simd::Inf<vT>(), 2), boost::simd::Inf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Minf<vT>(), 2), boost::simd::Minf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Nan<vT>(), 2), boost::simd::Nan<r_t>());
+#endif
+  NT2_TEST_EQUAL(round(boost::simd::Mhalf<vT>(), 2), boost::simd::Mhalf<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Mone<vT>(), 2), boost::simd::Mone<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::One<vT>(), 2), boost::simd::One<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Zero<vT>(), 2), boost::simd::Zero<r_t>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vT>()-boost::simd::Half<vT>(), 2),boost::simd::Maxflint<vT>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vT>(), 2),boost::simd::Maxflint<vT>());
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(1.44), 1), boost::simd::splat<vT>(1.4));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(1.45), 1), boost::simd::splat<vT>(1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(1.46), 1), boost::simd::splat<vT>(1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(2.45), 1), boost::simd::splat<vT>(2.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-1.44), 1), boost::simd::splat<vT>(-1.4));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-1.45), 1), boost::simd::splat<vT>(-1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-1.46), 1), boost::simd::splat<vT>(-1.5));
+  NT2_TEST_EQUAL(round(boost::simd::splat<vT>(-2.45), 1), boost::simd::splat<vT>(-2.5));
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(145), -2), boost::simd::splat<vT>(100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(150), -2), boost::simd::splat<vT>(200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(156), -2), boost::simd::splat<vT>(200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(250), -2), boost::simd::splat<vT>(300), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-145), -2), boost::simd::splat<vT>(-100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-155), -2), boost::simd::splat<vT>(-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-156), -2), boost::simd::splat<vT>(-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(boost::simd::splat<vT>(-255), -2), boost::simd::splat<vT>(-300), 0.5);
 } // end of test for floating_
 
 NT2_TEST_CASE_TPL ( round_unsigned_int,  BOOST_SIMD_SIMD_UNSIGNED_TYPES)

--- a/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
@@ -15,8 +15,11 @@
 #include <boost/simd/include/constants/oneo_10.hpp>
 #include <boost/simd/include/constants/zero.hpp>
 #include <boost/simd/include/constants/mone.hpp>
+#include <boost/simd/include/constants/two.hpp>
+#include <boost/simd/include/constants/three.hpp>
 #include <boost/simd/include/constants/hundred.hpp>
 #include <boost/simd/include/functions/sqr.hpp>
+#include <boost/simd/include/functions/splat.hpp>
 
 
 NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_SIMD_UNSIGNED_TYPES)
@@ -44,11 +47,11 @@ NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_SIMD_INTEGRAL_SIGNED_TYPES)
   typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
   typedef native<T,ext_t>                  vT;
   typedef typename boost::dispatch::meta::call<tenpower_(vT)>::type r_t;
-
   // specific values tests
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Mone<vT>()), boost::simd::Oneo_10<r_t>(), 0.5);
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::One<vT>()), boost::simd::Ten<r_t>(), 0.5);
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Two<vT>()), boost::simd::Hundred<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Three<vT>()),boost::simd::splat<r_t>(1000.0), 0.5);
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Mtwo<vT>()), boost::simd::sqr(boost::simd::Oneo_10<r_t>()), 0.5);
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<vT>()), boost::simd::One<r_t>(), 0.5);
 } // end of test for signed_int_

--- a/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
@@ -1,6 +1,5 @@
 //==============================================================================
-//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
-//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2015 J.T. Lapreste
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at

--- a/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
@@ -22,7 +22,7 @@
 #include <boost/simd/include/functions/splat.hpp>
 
 
-NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_SIMD_UNSIGNED_TYPES)
+NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_SIMD_UINT_CONVERT_TYPES)
 {
 
   using boost::simd::tenpower;
@@ -38,7 +38,7 @@ NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_SIMD_UNSIGNED_TYPES)
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<vT>()), boost::simd::One<r_t>(), 0.5);
 } // end of test for unsigned_int_
 
-NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_SIMD_INTEGRAL_SIGNED_TYPES)
+NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_SIMD_INT_CONVERT_TYPES)
 {
 
   using boost::simd::tenpower;

--- a/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
@@ -19,7 +19,7 @@
 #include <boost/simd/include/functions/sqr.hpp>
 
 
-NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_UNSIGNED_TYPES)
+NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_SIMD_UNSIGNED_TYPES)
 {
 
   using boost::simd::tenpower;
@@ -35,7 +35,7 @@ NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_UNSIGNED_TYPES)
   NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<vT>()), boost::simd::One<r_t>(), 0.5);
 } // end of test for unsigned_int_
 
-NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_INTEGRAL_SIGNED_TYPES)
+NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_SIMD_INTEGRAL_SIGNED_TYPES)
 {
 
   using boost::simd::tenpower;

--- a/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
+++ b/modules/boost/simd/base/unit/arithmetic/simd/tenpower.cpp
@@ -1,0 +1,55 @@
+//==============================================================================
+//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <boost/simd/arithmetic/include/functions/tenpower.hpp>
+#include <boost/simd/sdk/simd/native.hpp>
+#include <boost/dispatch/functor/meta/call.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/include/constants/one.hpp>
+#include <boost/simd/include/constants/oneo_10.hpp>
+#include <boost/simd/include/constants/zero.hpp>
+#include <boost/simd/include/constants/mone.hpp>
+#include <boost/simd/include/constants/hundred.hpp>
+#include <boost/simd/include/functions/sqr.hpp>
+
+
+NT2_TEST_CASE_TPL ( tenpower_unsigned_int, BOOST_SIMD_UNSIGNED_TYPES)
+{
+
+  using boost::simd::tenpower;
+  using boost::simd::tag::tenpower_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+  typedef typename boost::dispatch::meta::call<tenpower_(vT)>::type r_t;
+
+  // specific values tests
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::One<vT>()), boost::simd::Ten<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Two<vT>()), boost::simd::Hundred<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<vT>()), boost::simd::One<r_t>(), 0.5);
+} // end of test for unsigned_int_
+
+NT2_TEST_CASE_TPL ( tenpower_signed_int,  BOOST_SIMD_INTEGRAL_SIGNED_TYPES)
+{
+
+  using boost::simd::tenpower;
+  using boost::simd::tag::tenpower_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+  typedef typename boost::dispatch::meta::call<tenpower_(vT)>::type r_t;
+
+  // specific values tests
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Mone<vT>()), boost::simd::Oneo_10<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::One<vT>()), boost::simd::Ten<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Two<vT>()), boost::simd::Hundred<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Mtwo<vT>()), boost::simd::sqr(boost::simd::Oneo_10<r_t>()), 0.5);
+  NT2_TEST_ULP_EQUAL(tenpower(boost::simd::Zero<vT>()), boost::simd::One<r_t>(), 0.5);
+} // end of test for signed_int_

--- a/modules/core/base/bench/arithmetic/scalar/round.cpp
+++ b/modules/core/base/bench/arithmetic/scalar/round.cpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015          J.T. Lapreste
 //         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //

--- a/modules/core/exponential/include/nt2/exponential/functions/generic/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/generic/significants.hpp
@@ -1,8 +1,5 @@
 //==============================================================================
-//         Copyright 2015 - J.T. Lapreste
-//         Copyright 2003 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
-//         Copyright 2009 - 2011 LRI    UMR 8623 CNRS/Univ Paris Sud XI
-//         Copyright 2012 - 2014 MetaScale SAS
+//          Copyright 2015 - J.T. Lapreste
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at
@@ -20,6 +17,8 @@
 #include <nt2/include/functions/log10.hpp>
 #include <nt2/include/functions/minus.hpp>
 #include <nt2/include/functions/iceil.hpp>
+#include <nt2/include/functions/if_zero_else.hpp>
+#include <nt2/include/functions/is_eqz.hpp>
 #include <nt2/include/functions/is_invalid.hpp>
 #include <boost/dispatch/attributes.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
@@ -30,11 +29,11 @@
 
 namespace nt2 { namespace ext
 {
-  BOOST_DISPATCH_IMPLEMENT          ( significants_, tag::cpu_
-                                    , (A0)(A1)
-                                    , ((generic_< floating_<A0>>))
-                                      ((generic_< integer_<A1>>))
-                                    )
+  BOOST_DISPATCH_IMPLEMENT( significants_, tag::cpu_
+                          , (A0)(A1)
+                          , ((generic_< floating_<A0>>))
+                            ((generic_< integer_<A1>>))
+                          )
   {
     typedef A0 result_type;
 
@@ -48,10 +47,11 @@ namespace nt2 { namespace ext
       A0 fac = tenpower(exp);
       A0 scaled = round(a0*fac);
 #ifndef BOOST_SIMD_NO_INVALIDS
-      return if_else(is_invalid(a0), a0, scaled/fac);
+      A0 r = if_else(is_invalid(a0), a0, scaled/fac);
 #else
-      return scaled/fac;
+      A0 r =  scaled/fac;
 #endif
+      return if_zero_else(is_eqz(a0), r);
     }
   };
 

--- a/modules/core/exponential/include/nt2/exponential/functions/generic/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/generic/significants.hpp
@@ -1,0 +1,60 @@
+//==============================================================================
+//         Copyright 2015 - J.T. Lapreste
+//         Copyright 2003 - 2011 LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2011 LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2012 - 2014 MetaScale SAS
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_GENERIC_SIGNIFICANTS_HPP_INCLUDED
+#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_GENERIC_SIGNIFICANTS_HPP_INCLUDED
+
+#include <nt2/exponential/functions/significants.hpp>
+#include <nt2/include/functions/round.hpp>
+#include <nt2/include/functions/tenpower.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/all.hpp>
+#include <nt2/include/functions/is_gtz.hpp>
+#include <nt2/include/functions/log10.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/iceil.hpp>
+#include <nt2/include/functions/is_invalid.hpp>
+#include <boost/dispatch/attributes.hpp>
+#include <boost/dispatch/meta/as_integer.hpp>
+#include <boost/assert.hpp>
+#ifndef BOOST_SIMD_NO_INVALIDS
+#include <nt2/include/functions/scalar/is_invalid.hpp>
+#endif
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT          ( significants_, tag::cpu_
+                                    , (A0)(A1)
+                                    , ((generic_< floating_<A0>>))
+                                      ((generic_< integer_<A1>>))
+                                    )
+  {
+    typedef A0 result_type;
+
+    BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
+    {
+      BOOST_ASSERT_MSG( all(is_gtz(a1))
+                      , "Number of significant digits must be positive"
+                      );
+      typedef typename boost::dispatch::meta::as_integer<A0>::type iA0;
+      iA0 exp = a1 - iceil(log10(abs(a0)));
+      A0 fac = tenpower(exp);
+      A0 scaled = round(a0*fac);
+#ifndef BOOST_SIMD_NO_INVALIDS
+      return if_else(is_invalid(a0), a0, scaled/fac);
+#else
+      return scaled/fac;
+#endif
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/exponential/include/nt2/exponential/functions/scalar/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/scalar/significants.hpp
@@ -1,0 +1,60 @@
+//==============================================================================
+//          Copyright 2015 - J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_SCALAR_SIGNIFICANTS_HPP_INCLUDED
+#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_SCALAR_SIGNIFICANTS_HPP_INCLUDED
+
+#include <nt2/exponential/functions/significants.hpp>
+#include <nt2/include/functions/scalar/round.hpp>
+#include <nt2/include/functions/scalar/tenpower.hpp>
+#include <nt2/include/functions/scalar/abs.hpp>
+#include <nt2/include/functions/scalar/if_zero_else.hpp>
+#include <nt2/include/functions/scalar/is_eqz.hpp>
+#include <nt2/include/functions/scalar/log10.hpp>
+#include <nt2/include/functions/scalar/minus.hpp>
+#include <nt2/include/functions/scalar/iceil.hpp>
+#include <boost/dispatch/attributes.hpp>
+#include <boost/dispatch/meta/as_integer.hpp>
+#include <boost/assert.hpp>
+#include <boost/simd/operator/functions/details/assert_utils.hpp>
+#ifndef BOOST_SIMD_NO_INVALIDS
+#include <nt2/include/functions/scalar/if_else.hpp>
+#include <nt2/include/functions/scalar/is_invalid.hpp>
+#endif
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT( significants_, tag::cpu_
+                          , (A0)(A1)
+                          , ((scalar_< floating_<A0>>))
+                            ((scalar_< integer_<A1>>))
+                          )
+  {
+    typedef A0 result_type;
+
+    BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
+    {
+      BOOST_ASSERT_MSG( assert_all(is_gtz(a1))
+                      , "Number of significant digits must be positive"
+                      );
+      typedef typename boost::dispatch::meta::as_integer<A0>::type iA0;
+      if (is_eqz(a0)) return a0;
+      iA0 exp = a1 - iceil(log10(abs(a0)));
+      A0 fac = tenpower(exp);
+      A0 scaled = round(a0*fac);
+#ifndef BOOST_SIMD_NO_INVALIDS
+      A0 r = if_else(is_invalid(a0), a0, scaled/fac);
+#else
+      A0 r =  scaled/fac;
+#endif
+      return r;
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/exponential/include/nt2/exponential/functions/scalar/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/scalar/significants.hpp
@@ -14,6 +14,7 @@
 #include <nt2/include/functions/scalar/abs.hpp>
 #include <nt2/include/functions/scalar/if_zero_else.hpp>
 #include <nt2/include/functions/scalar/is_eqz.hpp>
+#include <nt2/include/functions/scalar/is_gtz.hpp>
 #include <nt2/include/functions/scalar/log10.hpp>
 #include <nt2/include/functions/scalar/minus.hpp>
 #include <nt2/include/functions/scalar/iceil.hpp>

--- a/modules/core/exponential/include/nt2/exponential/functions/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/significants.hpp
@@ -1,0 +1,65 @@
+//==============================================================================
+//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_EXPONENTIAL_FUNCTIONS_SIGNIFICANTS_HPP_INCLUDED
+#define NT2_EXPONENTIAL_FUNCTIONS_SIGNIFICANTS_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief significants generic tag
+
+     Represents the significants function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct significants_ : ext::elementwise_<significants_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::elementwise_<significants_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_significants_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::significants_, Site> dispatching_significants_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::significants_, Site>();
+   }
+   template<class... Args>
+   struct impl_significants_;
+  }
+  /*!
+    Compute the rounding to n significants digits
+
+    @par Semantic:
+
+    For every parameter of floating type T0 and integer n
+
+    @code
+    T0 r = significants(x, n);
+    @endcode
+
+    return the number rounded to n significants digits
+
+    @see @funcref{pow}, @funcref{boost::simd::sqrt}
+    @param a0
+
+    @return a value of the same type as the parameter
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::significants_, significants, 2)
+}
+
+#endif
+

--- a/modules/core/exponential/include/nt2/exponential/functions/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/significants.hpp
@@ -1,6 +1,5 @@
 //==============================================================================
-//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
-//         Copyright 2009 - 2012   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//          Copyright 2015 - J.T. Lapreste
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at
@@ -45,13 +44,13 @@ namespace nt2 { namespace tag
 
     @par Semantic:
 
-    For every parameter of floating type T0 and integer n
+    For every parameter of floating type T0 and strictly positive integer n
 
     @code
     T0 r = significants(x, n);
     @endcode
 
-    return the number rounded to n significants digits
+    is equivalent to round(x, m) where m is n-iceil(log10(abs(a0)))
 
     @see @funcref{pow}, @funcref{boost::simd::sqrt}
     @param a0

--- a/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
@@ -16,7 +16,7 @@
 #include <nt2/include/functions/simd/is_eqz.hpp>
 #include <nt2/include/functions/simd/log10.hpp>
 #include <nt2/include/functions/simd/minus.hpp>
-#include <nt2/include/functions/simd/divides.hpp<
+#include <nt2/include/functions/simd/divides.hpp>
 #include <nt2/include/functions/simd/multiplies.hpp>
 #include <nt2/include/functions/simd/iceil.hpp>
 #include <boost/dispatch/attributes.hpp>

--- a/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
@@ -23,6 +23,7 @@
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/assert.hpp>
 #include <boost/simd/operator/functions/details/assert_utils.hpp>
+#include <boost/mpl/equal_to.hpp>
 #ifndef BOOST_SIMD_NO_INVALIDS
 #include <nt2/include/functions/simd/if_else.hpp>
 #include <nt2/include/functions/simd/is_invalid.hpp>
@@ -30,11 +31,14 @@
 
 namespace nt2 { namespace ext
 {
-  BOOST_DISPATCH_IMPLEMENT( significants_, tag::cpu_
-                          , (A0)(X)(A1)
-                          , ((simd_< floating_<A0>, X>))
-                            ((simd_< integer_<A1>, X>))
-                          )
+  BOOST_DISPATCH_IMPLEMENT_IF( significants_, tag::cpu_
+                             , (A0)(X)(A1)
+                             , (boost::mpl::equal_to < boost::simd::meta::cardinal_of<A0>
+                                                     , boost::simd::meta::cardinal_of<A1>
+                                >)
+                             , ((simd_< floating_<A0>, X>))
+                               ((simd_< integer_<A1>, X>))
+                             )
   {
     typedef A0 result_type;
 

--- a/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
@@ -5,41 +5,40 @@
 //                 See accompanying file LICENSE.txt or copy at
 //                     http://www.boost.org/LICENSE_1_0.txt
 //==============================================================================
-#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_GENERIC_SIGNIFICANTS_HPP_INCLUDED
-#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_GENERIC_SIGNIFICANTS_HPP_INCLUDED
+#ifndef BOOST_SIMD_ARITHMETIC_FUNCTIONS_SIMD_COMMON_SIGNIFICANTS_HPP_INCLUDED
+#define BOOST_SIMD_ARITHMETIC_FUNCTIONS_SIMD_COMMON_SIGNIFICANTS_HPP_INCLUDED
 
 #include <nt2/exponential/functions/significants.hpp>
-#include <nt2/include/functions/round.hpp>
-#include <nt2/include/functions/tenpower.hpp>
-#include <nt2/include/functions/abs.hpp>
-#include <nt2/include/functions/all.hpp>
-#include <nt2/include/functions/is_gtz.hpp>
-#include <nt2/include/functions/log10.hpp>
-#include <nt2/include/functions/minus.hpp>
-#include <nt2/include/functions/iceil.hpp>
-#include <nt2/include/functions/if_zero_else.hpp>
-#include <nt2/include/functions/is_eqz.hpp>
-#include <nt2/include/functions/is_invalid.hpp>
+#include <nt2/include/functions/simd/round.hpp>
+#include <nt2/include/functions/simd/tenpower.hpp>
+#include <nt2/include/functions/simd/abs.hpp>
+#include <nt2/include/functions/simd/if_zero_else.hpp>
+#include <nt2/include/functions/simd/is_eqz.hpp>
+#include <nt2/include/functions/simd/log10.hpp>
+#include <nt2/include/functions/simd/minus.hpp>
+#include <nt2/include/functions/simd/iceil.hpp>
 #include <boost/dispatch/attributes.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>
 #include <boost/assert.hpp>
+#include <boost/simd/operator/functions/details/assert_utils.hpp>
 #ifndef BOOST_SIMD_NO_INVALIDS
-#include <nt2/include/functions/scalar/is_invalid.hpp>
+#include <nt2/include/functions/simd/if_else.hpp>
+#include <nt2/include/functions/simd/is_invalid.hpp>
 #endif
 
 namespace nt2 { namespace ext
 {
   BOOST_DISPATCH_IMPLEMENT( significants_, tag::cpu_
-                          , (A0)(A1)
-                          , ((generic_< floating_<A0>>))
-                            ((generic_< integer_<A1>>))
+                          , (A0)(X)(A1)
+                          , ((simd_< floating_<A0>, X>))
+                            ((simd_< integer_<A1>, X>))
                           )
   {
     typedef A0 result_type;
 
     BOOST_FORCEINLINE BOOST_SIMD_FUNCTOR_CALL(2)
     {
-      BOOST_ASSERT_MSG( all(is_gtz(a1))
+      BOOST_ASSERT_MSG( assert_all(is_gtz(a1))
                       , "Number of significant digits must be positive"
                       );
       typedef typename boost::dispatch::meta::as_integer<A0>::type iA0;

--- a/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/simd/common/significants.hpp
@@ -16,6 +16,8 @@
 #include <nt2/include/functions/simd/is_eqz.hpp>
 #include <nt2/include/functions/simd/log10.hpp>
 #include <nt2/include/functions/simd/minus.hpp>
+#include <nt2/include/functions/simd/divides.hpp<
+#include <nt2/include/functions/simd/multiplies.hpp>
 #include <nt2/include/functions/simd/iceil.hpp>
 #include <boost/dispatch/attributes.hpp>
 #include <boost/dispatch/meta/as_integer.hpp>

--- a/modules/core/exponential/unit/scalar/CMakeLists.txt
+++ b/modules/core/exponential/unit/scalar/CMakeLists.txt
@@ -27,6 +27,7 @@ SET( SOURCES
   realpow.cpp
   reallog.cpp
   realsqrt.cpp
+  significants.cpp
   sqrt1pm1.cpp
 # List of scalar test files for toolbox exponential
    )

--- a/modules/core/exponential/unit/scalar/significants.cpp
+++ b/modules/core/exponential/unit/scalar/significants.cpp
@@ -36,6 +36,7 @@ NT2_TEST_CASE_TPL ( significants,  BOOST_SIMD_REAL_TYPES)
   NT2_TEST_ULP_EQUAL(significants(nt2::Minf<T>(), 1), nt2::Minf<r_t>(), 0.5);
   NT2_TEST_ULP_EQUAL(significants(nt2::Nan<T>(), 1), nt2::Nan<r_t>(), 0.5);
 #endif
+  NT2_TEST_ULP_EQUAL(significants(T(0), 1), T(0), 0.5);
   NT2_TEST_ULP_EQUAL(significants(T(25.34), 1), T(30), 0.5);
   NT2_TEST_ULP_EQUAL(significants(T(25.34), 2), T(25), 0.5);
   NT2_TEST_ULP_EQUAL(significants(T(25.34), 3), T(25.3), 0.5);

--- a/modules/core/exponential/unit/scalar/significants.cpp
+++ b/modules/core/exponential/unit/scalar/significants.cpp
@@ -1,0 +1,48 @@
+//==============================================================================
+//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/significants.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/meta/as_integer.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/sdk/meta/as_floating.hpp>
+#include <nt2/sdk/meta/as_integer.hpp>
+
+NT2_TEST_CASE_TPL ( significants,  BOOST_SIMD_REAL_TYPES)
+{
+
+  using nt2::significants;
+  using nt2::tag::significants_;
+  typedef typename nt2::meta::as_integer<T>::type iT;
+  typedef typename boost::dispatch::meta::call<significants_(T, iT)>::type r_t;
+  typedef T wished_r_t;
+
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS( r_t, wished_r_t );
+
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(significants(nt2::Inf<T>(), 1), nt2::Inf<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::Minf<T>(), 1), nt2::Minf<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::Nan<T>(), 1), nt2::Nan<r_t>(), 0.5);
+#endif
+  NT2_TEST_ULP_EQUAL(significants(T(25.34), 1), T(30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(25.34), 2), T(25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(25.34), 3), T(25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(25.34), 4), T(25.34), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(-25.34), 1), T(-30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(-25.34), 2), T(-25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(-25.34), 3), T(-25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(T(-25.34), 4), T(-25.34), 0.5);
+}
+

--- a/modules/core/exponential/unit/scalar/significants.cpp
+++ b/modules/core/exponential/unit/scalar/significants.cpp
@@ -1,5 +1,5 @@
 //==============================================================================
-//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2015 J.T. Lapreste
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at

--- a/modules/core/exponential/unit/simd/CMakeLists.txt
+++ b/modules/core/exponential/unit/simd/CMakeLists.txt
@@ -28,6 +28,7 @@ SET( SOURCES
   realpow.cpp
   pow2.cpp
   pow_abs.cpp
+  significants.cpp
 # List of simd test files for toolbox exponential
    )
 

--- a/modules/core/exponential/unit/simd/significants.cpp
+++ b/modules/core/exponential/unit/simd/significants.cpp
@@ -1,0 +1,56 @@
+//==============================================================================
+//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/significants.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <boost/simd/sdk/simd/native.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/include/functions/splat.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <boost/simd/sdk/simd/io.hpp>
+
+#include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+
+NT2_TEST_CASE_TPL ( significants,  NT2_SIMD_REAL_TYPES)
+{
+  using nt2::significants;
+  using nt2::tag::significants_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+  typedef typename nt2::meta::as_integer<vT>::type ivT;
+
+  typedef typename nt2::meta::call<significants_(vT, ivT)>::type r_t;
+  typedef vT wished_r_t;
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(significants(nt2::Inf<vT>(), 1), nt2::Inf<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::Minf<vT>(), 1), nt2::Minf<r_t>(), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::Nan<vT>(), 1), nt2::Nan<r_t>(), 0.5);
+#endif
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(25.34), nt2::splat<ivT>(1)), nt2::splat<vT>(30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(25.34), nt2::splat<ivT>(2)), nt2::splat<vT>(25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(25.34), nt2::splat<ivT>(3)), nt2::splat<vT>(25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(25.34), nt2::splat<ivT>(4)), nt2::splat<vT>(25.34), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(-25.34), nt2::splat<ivT>(1)), nt2::splat<vT>(-30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(-25.34), nt2::splat<ivT>(2)), nt2::splat<vT>(-25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(-25.34), nt2::splat<ivT>(3)), nt2::splat<vT>(-25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<vT>(-25.34), nt2::splat<ivT>(4)), nt2::splat<vT>(-25.34), 0.5);
+}

--- a/modules/core/exponential/unit/simd/significants.cpp
+++ b/modules/core/exponential/unit/simd/significants.cpp
@@ -1,5 +1,5 @@
 //==============================================================================
-//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//         Copyright 2015 J.T. Lapreste
 //
 //          Distributed under the Boost Software License, Version 1.0.
 //                 See accompanying file LICENSE.txt or copy at

--- a/modules/type/complex/base/include/nt2/arithmetic/functions/complex/generic/round.hpp
+++ b/modules/type/complex/base/include/nt2/arithmetic/functions/complex/generic/round.hpp
@@ -39,7 +39,29 @@ namespace boost { namespace simd { namespace ext
       return bitwise_cast<result_type>(nt2::round(nt2::real(a0)));
     }
   };
+  BOOST_DISPATCH_IMPLEMENT  ( round_, tag::cpu_, (A0)(A1)
+                            , (generic_< complex_< arithmetic_<A0> > >)
+                              (generic_< integer_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+    NT2_FUNCTOR_CALL(2)
+    {
+      return result_type(round(nt2::real(a0), a1),round(nt2::imag(a0), a1));
+    }
+  };
 
+  BOOST_DISPATCH_IMPLEMENT  ( round_, tag::cpu_, (A0)(A1)
+                            , (generic_< dry_< arithmetic_<A0> > >)
+                              (generic_< integer_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+    NT2_FUNCTOR_CALL(2)
+    {
+      return bitwise_cast<result_type>(nt2::round(nt2::real(a0, a1)));
+    }
+  };
 } } }
 
 #endif

--- a/modules/type/complex/base/include/nt2/arithmetic/functions/complex/generic/round.hpp
+++ b/modules/type/complex/base/include/nt2/arithmetic/functions/complex/generic/round.hpp
@@ -63,6 +63,29 @@ namespace boost { namespace simd { namespace ext
       return bitwise_cast<result_type>(nt2::round(nt2::real(a0), a1));
     }
   };
+   BOOST_DISPATCH_IMPLEMENT  ( round_, tag::cpu_, (A0)(A1)
+                            , (generic_< complex_< arithmetic_<A0> > >)
+                              (scalar_< integer_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+    NT2_FUNCTOR_CALL(2)
+    {
+      return result_type(round(nt2::real(a0), a1),round(nt2::imag(a0), a1));
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( round_, tag::cpu_, (A0)(A1)
+                            , (generic_< dry_< arithmetic_<A0> > >)
+                              (scalar_< integer_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+    NT2_FUNCTOR_CALL(2)
+    {
+      return bitwise_cast<result_type>(nt2::round(nt2::real(a0), a1));
+    }
+  };
 } } }
 
 #endif

--- a/modules/type/complex/base/include/nt2/arithmetic/functions/complex/generic/round.hpp
+++ b/modules/type/complex/base/include/nt2/arithmetic/functions/complex/generic/round.hpp
@@ -15,6 +15,7 @@
 #include <nt2/sdk/complex/meta/as_complex.hpp>
 #include <nt2/sdk/complex/meta/as_real.hpp>
 #include <nt2/sdk/complex/meta/as_dry.hpp>
+#include <nt2/include/constants/zero.hpp>
 
 namespace boost { namespace simd { namespace ext
 {
@@ -59,7 +60,7 @@ namespace boost { namespace simd { namespace ext
     typedef A0 result_type;
     NT2_FUNCTOR_CALL(2)
     {
-      return bitwise_cast<result_type>(nt2::round(nt2::real(a0, a1)));
+      return bitwise_cast<result_type>(nt2::round(nt2::real(a0), a1));
     }
   };
 } } }

--- a/modules/type/complex/base/unit/arithmetic/scalar/round.cpp
+++ b/modules/type/complex/base/unit/arithmetic/scalar/round.cpp
@@ -1,4 +1,5 @@
 //==============================================================================
+//         Copyright 2015          J.T. Lapreste
 //         Copyright 2003 - 2013   LASMEA UMR 6602 CNRS/Univ. Clermont II
 //         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
 //
@@ -11,6 +12,7 @@
 #include <boost/dispatch/functor/meta/call.hpp>
 #include <nt2/sdk/functor/meta/call.hpp>
 #include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
 #include <nt2/sdk/unit/tests/type_expr.hpp>
 #include <complex>
 #include <nt2/sdk/complex/complex.hpp>
@@ -52,3 +54,40 @@ NT2_TEST_CASE_TPL ( round_real,  BOOST_SIMD_REAL_TYPES)
   NT2_TEST_EQUAL(round(nt2::One<cT>()), nt2::One<cT>());
   NT2_TEST_EQUAL(round(nt2::Zero<cT>()), nt2::Zero<cT>());
 }
+
+NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
+{
+
+  using boost::simd::round;
+  using boost::simd::tag::round_;
+ typedef typename std::complex<T> cT;
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(round(boost::simd::Inf<cT>(), 2), boost::simd::Inf<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::Minf<cT>(), 2), boost::simd::Minf<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::Nan<cT>(), 2), boost::simd::Nan<cT>());
+#endif
+  NT2_TEST_EQUAL(round(boost::simd::Mhalf<cT>(), 2), boost::simd::Mhalf<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::Mone<cT>(), 2), boost::simd::Mone<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::One<cT>(), 2), boost::simd::One<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::Zero<cT>(), 2), boost::simd::Zero<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<cT>()-boost::simd::Half<cT>(), 2),boost::simd::Maxflint<cT>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<cT>(), 2),boost::simd::Maxflint<cT>());
+  NT2_TEST_EQUAL(round(cT(1.44, 1.44), 1), cT(1.4,1.4 ));
+  NT2_TEST_EQUAL(round(cT(1.45, 1.45), 1), cT(1.5,1.5 ));
+  NT2_TEST_EQUAL(round(cT(1.46, 1.46), 1), cT(1.5,1.5 ));
+  NT2_TEST_EQUAL(round(cT(2.45, 2.45), 1), cT(2.5,2.5 ));
+  NT2_TEST_EQUAL(round(cT(-1.44,-1.44), 1), cT(-1.4,-1.4));
+  NT2_TEST_EQUAL(round(cT(-1.45,-1.45), 1), cT(-1.5,-1.5));
+  NT2_TEST_EQUAL(round(cT(-1.46,-1.46), 1), cT(-1.5,-1.5));
+  NT2_TEST_EQUAL(round(cT(-2.45,-2.45), 1), cT(-2.5,-2.5));
+  NT2_TEST_ULP_EQUAL(round(cT(145,145), -2), cT(100,100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(150,150), -2), cT(200,200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(156,156), -2), cT(200,200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(250,250), -2), cT(300,300), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(-145,-145), -2), cT(-100,-100), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(-155,-155), -2), cT(-200,-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(-156,-156), -2), cT(-200,-200), 0.5);
+  NT2_TEST_ULP_EQUAL(round(cT(-255,-255), -2), cT(-300,-300), 0.5);
+} // end of test for floating_

--- a/modules/type/complex/base/unit/arithmetic/simd/round.cpp
+++ b/modules/type/complex/base/unit/arithmetic/simd/round.cpp
@@ -26,13 +26,17 @@
 #include <boost/simd/sdk/config.hpp>
 
 #include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/mhalf.hpp>
+#include <nt2/include/constants/half.hpp>
 #include <nt2/include/constants/one.hpp>
 #include <nt2/include/constants/zero.hpp>
 #include <nt2/include/constants/inf.hpp>
 #include <nt2/include/constants/minf.hpp>
 #include <nt2/include/constants/nan.hpp>
+#include <nt2/include/constants/maxflint.hpp>
+#include <nt2/table.hpp>
 
-NT2_TEST_CASE_TPL ( abs_cplx,  BOOST_SIMD_SIMD_REAL_TYPES)
+NT2_TEST_CASE_TPL ( round_cplx,  BOOST_SIMD_SIMD_REAL_TYPES)
 {
   using nt2::round;
   using nt2::tag::round_;
@@ -64,29 +68,30 @@ NT2_TEST_CASE_TPL ( abs_cplx,  BOOST_SIMD_SIMD_REAL_TYPES)
     NT2_TEST_ULP_EQUAL(nt2::round(nt2::Zero<vdT>()), nt2::Zero<vdT>(),0);
 }
 
-NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
+NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_SIMD_REAL_TYPES)
 {
 
-  using boost::simd::round;
-  using boost::simd::tag::round_;
+  using nt2::round;
+  using nt2::tag::round_;
   typedef typename std::complex<T> cT;
   using boost::simd::native;
   typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
   typedef native<cT,ext_t>                vcT;
-  typedef typename nt2::dry<T>             dT;
+  typedef nt2::dry<T>                      dT;
+  typedef native<dT,ext_t>                vdT;
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS
-  NT2_TEST_EQUAL(round(boost::simd::Inf<vcT>(), 2), boost::simd::Inf<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::Minf<vcT>(), 2), boost::simd::Minf<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::Nan<vcT>(), 2), boost::simd::Nan<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Inf<vcT>(), 2), nt2::Inf<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Minf<vcT>(), 2), nt2::Minf<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Nan<vcT>(), 2), nt2::Nan<vcT>());
 #endif
-  NT2_TEST_EQUAL(round(boost::simd::Mhalf<vcT>(), 2), boost::simd::Mhalf<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::Mone<vcT>(), 2), boost::simd::Mone<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::One<vcT>(), 2), boost::simd::One<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::Zero<vcT>(), 2), boost::simd::Zero<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vcT>()-boost::simd::Half<vcT>(), 2),boost::simd::Maxflint<vcT>());
-  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vcT>(), 2),boost::simd::Maxflint<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Mhalf<vcT>(), 2), nt2::Mhalf<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Mone<vcT>(), 2), nt2::Mone<vcT>());
+  NT2_TEST_EQUAL(round(nt2::One<vcT>(), 2), nt2::One<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Zero<vcT>(), 2), nt2::Zero<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Maxflint<vcT>()-nt2::Half<vcT>(), 2),nt2::Maxflint<vcT>());
+  NT2_TEST_EQUAL(round(nt2::Maxflint<vcT>(), 2),nt2::Maxflint<vcT>());
   NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(1.44, 1.44)), 1), nt2::splat<vcT>(cT(1.4,1.4 )));
   NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(1.45, 1.45)), 1), nt2::splat<vcT>(cT(1.5,1.5 )));
   NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(1.46, 1.46)), 1), nt2::splat<vcT>(cT(1.5,1.5 )));
@@ -103,5 +108,60 @@ NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
   NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-155,-155)), -2), nt2::splat<vcT>(cT(-200,-200)), 0.5);
   NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-156,-156)), -2), nt2::splat<vcT>(cT(-200,-200)), 0.5);
   NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-255,-255)), -2), nt2::splat<vcT>(cT(-300,-300)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vdT>(dT(-1.11)), 1),  nt2::splat<vdT>(dT(-1.1)),0);
+} // end of test for floating_
+
+NT2_TEST_CASE_TPL ( round_real2b,  BOOST_SIMD_SIMD_REAL_TYPES)
+{
+
+  using nt2::round;
+  using nt2::tag::round_;
+  typedef typename std::complex<T> cT;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<cT,ext_t>                vcT;
+  typedef native<T ,ext_t>                vT;
+  typedef typename nt2::meta::as_integer<vT>::type viT;
+  typedef nt2::dry<T>                      dT;
+  typedef native<dT ,ext_t>               vdT;
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(nt2::round(nt2::Inf<vcT>(), nt2::splat<viT>(2)), nt2::Inf<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::Minf<vcT>(), nt2::splat<viT>(2)), nt2::Minf<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::Nan<vcT>(), nt2::splat<viT>(2)), nt2::Nan<vcT>());
+#endif
+  NT2_TEST_EQUAL(nt2::round(nt2::Mhalf<vcT>(), nt2::splat<viT>(2)), nt2::Mhalf<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::Mone<vcT>(), nt2::splat<viT>(2)), nt2::Mone<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::One<vcT>(), nt2::splat<viT>(2)), nt2::One<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::Zero<vcT>(), nt2::splat<viT>(2)), nt2::Zero<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::Maxflint<vcT>()-nt2::Half<vcT>(), nt2::splat<viT>(2)),nt2::Maxflint<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::Maxflint<vcT>(), nt2::splat<viT>(2)),nt2::Maxflint<vcT>());
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(1.44, 1.44)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(1.4,1.4 )));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(1.45, 1.45)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(1.5,1.5 )));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(1.46, 1.46)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(1.5,1.5 )));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(2.45, 2.45)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(2.5,2.5 )));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(-1.44,-1.44)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(-1.4,-1.4)));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(-1.45,-1.45)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(-1.5,-1.5)));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(-1.46,-1.46)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(-1.5,-1.5)));
+  NT2_TEST_EQUAL(nt2::round(nt2::splat<vcT>(cT(-2.45,-2.45)), nt2::splat<viT>(1)), nt2::splat<vcT>(cT(-2.5,-2.5)));
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(145,145)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(100,100)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(150,150)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(200,200)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(156,156)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(200,200)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(250,250)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(300,300)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(-145,-145)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(-100,-100)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(-155,-155)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(-200,-200)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(-156,-156)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(-200,-200)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(-255,-255)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(-300,-300)), 0.5);
+  NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vdT>(dT(-1.11)), nt2::splat<viT>(1)),  nt2::splat<vdT>(dT(-1.1)),0);
+
+//   vdT a = nt2::splat<vdT>(dT(1.44));
+//   viT i = nt2::splat<viT>(1);
+//   vdT b = nt2::splat<vdT>(dT(1.4));
+//   NT2_DISPLAY(a);
+//   NT2_DISPLAY(i);
+//   NT2_DISPLAY(b);
+//  NT2_TEST_ULP_EQUAL(nt2::round(da, i), db, 0.5);
+//  NT2_TEST_ULP_EQUAL(nt2::round(vdT(nt2::splat<vT>(T(1.44))), nt2::splat<viT>(1)), vdT(nt2::splat<vT>(T(1.4))), 0.5);
 } // end of test for floating_
 

--- a/modules/type/complex/base/unit/arithmetic/simd/round.cpp
+++ b/modules/type/complex/base/unit/arithmetic/simd/round.cpp
@@ -11,6 +11,7 @@
 #include <boost/dispatch/functor/meta/call.hpp>
 #include <nt2/sdk/functor/meta/call.hpp>
 #include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
 #include <nt2/sdk/unit/tests/type_expr.hpp>
 #include <boost/simd/sdk/simd/io.hpp>
 #include <boost/simd/sdk/simd/native.hpp>
@@ -20,6 +21,7 @@
 #include <nt2/sdk/unit/tests/ulp.hpp>
 #include <nt2/sdk/meta/as_integer.hpp>
 #include <nt2/include/functions/splat.hpp>
+#include <nt2/include/functions/minus.hpp>
 #include <nt2/sdk/unit/module.hpp>
 #include <boost/simd/sdk/config.hpp>
 
@@ -61,3 +63,46 @@ NT2_TEST_CASE_TPL ( abs_cplx,  BOOST_SIMD_SIMD_REAL_TYPES)
     NT2_TEST_ULP_EQUAL(nt2::round(nt2::One<vdT>()), nt2::One<vdT>(),0);
     NT2_TEST_ULP_EQUAL(nt2::round(nt2::Zero<vdT>()), nt2::Zero<vdT>(),0);
 }
+
+NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
+{
+
+  using boost::simd::round;
+  using boost::simd::tag::round_;
+  typedef typename std::complex<T> cT;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<cT,ext_t>                vcT;
+  typedef typename nt2::dry<T>             dT;
+  typedef native<dT,ext_t>                vdT;
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(round(boost::simd::Inf<vcT>(), 2), boost::simd::Inf<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::Minf<vcT>(), 2), boost::simd::Minf<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::Nan<vcT>(), 2), boost::simd::Nan<vcT>());
+#endif
+  NT2_TEST_EQUAL(round(boost::simd::Mhalf<vcT>(), 2), boost::simd::Mhalf<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::Mone<vcT>(), 2), boost::simd::Mone<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::One<vcT>(), 2), boost::simd::One<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::Zero<vcT>(), 2), boost::simd::Zero<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vcT>()-boost::simd::Half<vcT>(), 2),boost::simd::Maxflint<vcT>());
+  NT2_TEST_EQUAL(round(boost::simd::Maxflint<vcT>(), 2),boost::simd::Maxflint<vcT>());
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(1.44, 1.44)), 1), nt2::splat<vcT>(cT(1.4,1.4 )));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(1.45, 1.45)), 1), nt2::splat<vcT>(cT(1.5,1.5 )));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(1.46, 1.46)), 1), nt2::splat<vcT>(cT(1.5,1.5 )));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(2.45, 2.45)), 1), nt2::splat<vcT>(cT(2.5,2.5 )));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(-1.44,-1.44)), 1), nt2::splat<vcT>(cT(-1.4,-1.4)));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(-1.45,-1.45)), 1), nt2::splat<vcT>(cT(-1.5,-1.5)));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(-1.46,-1.46)), 1), nt2::splat<vcT>(cT(-1.5,-1.5)));
+  NT2_TEST_EQUAL(round(nt2::splat<vcT>(cT(-2.45,-2.45)), 1), nt2::splat<vcT>(cT(-2.5,-2.5)));
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(145,145)), -2), nt2::splat<vcT>(cT(100,100)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(150,150)), -2), nt2::splat<vcT>(cT(200,200)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(156,156)), -2), nt2::splat<vcT>(cT(200,200)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(250,250)), -2), nt2::splat<vcT>(cT(300,300)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-145,-145)), -2), nt2::splat<vcT>(cT(-100,-100)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-155,-155)), -2), nt2::splat<vcT>(cT(-200,-200)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-156,-156)), -2), nt2::splat<vcT>(cT(-200,-200)), 0.5);
+  NT2_TEST_ULP_EQUAL(round(nt2::splat<vcT>(cT(-255,-255)), -2), nt2::splat<vcT>(cT(-300,-300)), 0.5);
+} // end of test for floating_
+

--- a/modules/type/complex/base/unit/arithmetic/simd/round.cpp
+++ b/modules/type/complex/base/unit/arithmetic/simd/round.cpp
@@ -34,7 +34,6 @@
 #include <nt2/include/constants/minf.hpp>
 #include <nt2/include/constants/nan.hpp>
 #include <nt2/include/constants/maxflint.hpp>
-#include <nt2/table.hpp>
 
 NT2_TEST_CASE_TPL ( round_cplx,  BOOST_SIMD_SIMD_REAL_TYPES)
 {

--- a/modules/type/complex/base/unit/arithmetic/simd/round.cpp
+++ b/modules/type/complex/base/unit/arithmetic/simd/round.cpp
@@ -153,14 +153,5 @@ NT2_TEST_CASE_TPL ( round_real2b,  BOOST_SIMD_SIMD_REAL_TYPES)
   NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(-156,-156)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(-200,-200)), 0.5);
   NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vcT>(cT(-255,-255)), nt2::splat<viT>(-2)), nt2::splat<vcT>(cT(-300,-300)), 0.5);
   NT2_TEST_ULP_EQUAL(nt2::round(nt2::splat<vdT>(dT(-1.11)), nt2::splat<viT>(1)),  nt2::splat<vdT>(dT(-1.1)),0);
-
-//   vdT a = nt2::splat<vdT>(dT(1.44));
-//   viT i = nt2::splat<viT>(1);
-//   vdT b = nt2::splat<vdT>(dT(1.4));
-//   NT2_DISPLAY(a);
-//   NT2_DISPLAY(i);
-//   NT2_DISPLAY(b);
-//  NT2_TEST_ULP_EQUAL(nt2::round(da, i), db, 0.5);
-//  NT2_TEST_ULP_EQUAL(nt2::round(vdT(nt2::splat<vT>(T(1.44))), nt2::splat<viT>(1)), vdT(nt2::splat<vT>(T(1.4))), 0.5);
 } // end of test for floating_
 

--- a/modules/type/complex/base/unit/arithmetic/simd/round.cpp
+++ b/modules/type/complex/base/unit/arithmetic/simd/round.cpp
@@ -74,7 +74,6 @@ NT2_TEST_CASE_TPL ( round_real2,  BOOST_SIMD_REAL_TYPES)
   typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
   typedef native<cT,ext_t>                vcT;
   typedef typename nt2::dry<T>             dT;
-  typedef native<dT,ext_t>                vdT;
 
   // specific values tests
 #ifndef BOOST_SIMD_NO_INVALIDS

--- a/modules/type/complex/exponential/include/nt2/exponential/functions/complex/generic/significants.hpp
+++ b/modules/type/complex/exponential/include/nt2/exponential/functions/complex/generic/significants.hpp
@@ -1,0 +1,48 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_EXPONENTIAL_FUNCTIONS_COMPLEX_GENERIC_SIGNIFICANTS_HPP_INCLUDED
+#define NT2_EXPONENTIAL_FUNCTIONS_COMPLEX_GENERIC_SIGNIFICANTS_HPP_INCLUDED
+
+#include <nt2/exponential/functions/significants.hpp>
+#include <nt2/include/functions/real.hpp>
+#include <nt2/include/functions/imag.hpp>
+#include <nt2/include/functions/bitwise_cast.hpp>
+#include <nt2/sdk/complex/complex.hpp>
+#include <boost/dispatch/attributes.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( significants_, tag::cpu_
+                            , (A0)(A1)
+                            , (generic_< complex_<floating_<A0> > >)
+                              (generic_< integer_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+    NT2_FUNCTOR_CALL(2)
+    {
+      return result_type(significants(nt2::real(a0), a1),significants(nt2::imag(a0), a1));
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( significants_, tag::cpu_
+                            , (A0)(A1)
+                            , (generic_< dry_<floating_<A0> > >)
+                              (generic_< integer_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+    NT2_FUNCTOR_CALL(2)
+    {
+      return bitwise_cast<result_type>(nt2::significants(nt2::real(a0), a1));
+    }
+  };
+} }
+
+
+#endif

--- a/modules/type/complex/exponential/unit/scalar/CMakeLists.txt
+++ b/modules/type/complex/exponential/unit/scalar/CMakeLists.txt
@@ -22,6 +22,7 @@ set( SOURCES
    pow2.cpp
    pow.cpp
    pow_abs.cpp
+   significants.cpp
    )
 
 nt2_module_add_tests(type.complex.exponential.scalar.unit ${SOURCES})

--- a/modules/type/complex/exponential/unit/scalar/significants.cpp
+++ b/modules/type/complex/exponential/unit/scalar/significants.cpp
@@ -1,0 +1,47 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/include/functions/significants.hpp>
+
+#include <boost/dispatch/functor/meta/call.hpp>
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/meta/as_integer.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <complex>
+#include <nt2/sdk/complex/complex.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+
+NT2_TEST_CASE_TPL ( significants,  BOOST_SIMD_REAL_TYPES)
+{
+
+  using nt2::significants;
+  using nt2::tag::significants_;
+  typedef std::complex<T> cT;
+
+
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_EQUAL(significants(nt2::Inf<cT>(), 1), nt2::Inf<cT>());
+  NT2_TEST_EQUAL(significants(nt2::Minf<cT>(), 1), nt2::Minf<cT>());
+  NT2_TEST_EQUAL(significants(nt2::Nan<cT>(), 1), nt2::Nan<cT>());
+#endif
+  NT2_TEST_ULP_EQUAL(significants(cT(0), 1), cT(0), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(25.34), 1), cT(30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(25.34), 2), cT(25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(25.34), 3), cT(25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(25.34), 4), cT(25.34), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(-25.34), 1), cT(-30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(-25.34), 2), cT(-25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(-25.34), 3), cT(-25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(cT(-25.34), 4), cT(-25.34), 0.5);
+}
+

--- a/modules/type/complex/exponential/unit/simd/CMakeLists.txt
+++ b/modules/type/complex/exponential/unit/simd/CMakeLists.txt
@@ -21,6 +21,7 @@ set( SOURCES
   pow2.cpp
   pow.cpp
   pow_abs.cpp
+  significants.cpp
   )
 
 nt2_module_add_tests(type.complex.exponential.simd.unit ${SOURCES})

--- a/modules/type/complex/exponential/unit/simd/significants.cpp
+++ b/modules/type/complex/exponential/unit/simd/significants.cpp
@@ -1,0 +1,56 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/significants.hpp>
+
+#include <boost/dispatch/functor/meta/call.hpp>
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <boost/simd/sdk/simd/io.hpp>
+#include <boost/simd/sdk/simd/native.hpp>
+#include <complex>
+#include <nt2/sdk/complex/complex.hpp>
+#include <nt2/sdk/complex/dry.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/include/functions/splat.hpp>
+
+
+#include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+
+
+NT2_TEST_CASE_TPL ( significants,  NT2_SIMD_REAL_TYPES)
+{
+  using nt2::significants;
+  using nt2::tag::significants_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef std::complex<T> cT;
+  typedef native<cT,ext_t>                cvT;
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(significants(nt2::Inf<cvT>(), 1), nt2::Inf<cvT>(), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::Minf<cvT>(), 1), nt2::Minf<cvT>(), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::Nan<cvT>(), 1), nt2::Nan<cvT>(), 0.5);
+#endif
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(25.34)),  1), nt2::splat<cvT>(30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(25.34)),  2), nt2::splat<cvT>(25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(25.34)),  3), nt2::splat<cvT>(25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(25.34)),  4), nt2::splat<cvT>(25.34), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(-25.34)), 1), nt2::splat<cvT>(-30), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(-25.34)), 2), nt2::splat<cvT>(-25), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(-25.34)), 3), nt2::splat<cvT>(-25.3), 0.5);
+  NT2_TEST_ULP_EQUAL(significants(nt2::splat<cvT>(cT(-25.34)), 4), nt2::splat<cvT>(-25.34), 0.5);
+}


### PR DESCRIPTION
matlab proposes round with 1,2 or 3 parameters.

We have the 1 parameter version.

This pull request adds the two parameters version as round(x,n) to round x with n decimal digits in
boost/simd/base/arithmetic and an auxilliary function tenpower that computes the floating value 10^n
where n is an integer. 

Finally, the three parameters version is provided as a member of core/exponential module under the name of 'significants' and obviously with only 2 parameters: significants(x,n) being equivalent to matlab call
round(x,n,'significant')

The rationale is that this last functor uses log10 which is not a boost/simd member up to now as so cannot easily be defined in boost/simd.