### PR TITLE
psiha functions exp(-1/x) and 1-exp(-1/x), named exprecneg and exprecneg...

### DIFF
--- a/modules/core/exponential/include/nt2/exponential/functions/exprecneg.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/exprecneg.hpp
@@ -1,0 +1,69 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_EXPONENTIAL_FUNCTIONS_EXPRECNEG_HPP_INCLUDED
+#define NT2_EXPONENTIAL_FUNCTIONS_EXPRECNEG_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+
+
+namespace nt2 {
+  namespace tag {
+    /*!
+      @brief exprecneg generic tag
+
+      Represents the exprecneg function in generic contexts.
+
+      @par Models:
+         Hierarchy
+    **/
+    struct exprecneg_ : ext::elementwise_<exprecneg_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::elementwise_<exprecneg_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&& ... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_exprecneg_( ext::adl_helper(),
+                                static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::exprecneg_, Site>
+    dispatching_exprecneg_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::exprecneg_, Site>();
+    }
+    template<class... Args>
+    struct impl_exprecneg_;
+  }
+  /*!
+    Computes the  function: \f$e^{-\frac1x}\f$
+
+    @par Semantic:
+
+    For every parameter of floating type T0
+
+    @code
+    T0 r = exprecneg(a0);
+    @endcode
+
+    is similar to
+    @code
+    T0 r = exp(-rec((a0)));
+    @endcode
+
+
+    @see @funcref{exp}, @funcref{exprecnegc}
+    @param a0
+
+    @return a value of the same type as the (floating) input parameter
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::exprecneg_, exprecneg, 1)
+}
+
+#endif
+

--- a/modules/core/exponential/include/nt2/exponential/functions/exprecnegc.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/exprecnegc.hpp
@@ -1,0 +1,69 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_EXPONENTIAL_FUNCTIONS_EXPRECNEGC_HPP_INCLUDED
+#define NT2_EXPONENTIAL_FUNCTIONS_EXPRECNEGC_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+
+
+namespace nt2 {
+  namespace tag {
+    /*!
+      @brief exprecnegc generic tag
+
+      Represents the exprecnegc function in generic contexts.
+
+      @par Models:
+         Hierarchy
+    **/
+    struct exprecnegc_ : ext::elementwise_<exprecnegc_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::elementwise_<exprecnegc_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&& ... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_exprecnegc_( ext::adl_helper(),
+                                static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::exprecnegc_, Site>
+    dispatching_exprecnegc_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::exprecnegc_, Site>();
+    }
+    template<class... Args>
+    struct impl_exprecnegc_;
+  }
+  /*!
+    Computes the  function: \f$1-e^{-\frac1x}\f$
+
+    @par Semantic:
+
+    For every parameter of floating type T0
+
+    @code
+    T0 r = exprecnegc(a0);
+    @endcode
+
+    is similar to
+    @code
+    T0 r = 1-exp(-rec((a0)));
+    @endcode
+
+
+    @see @funcref{exp}, @funcref{exprecneg}
+    @param a0
+
+    @return a value of the same type as the (floating) input parameter
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::exprecnegc_, exprecnegc, 1)
+}
+
+#endif
+

--- a/modules/core/exponential/include/nt2/exponential/functions/generic/exprecneg.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/generic/exprecneg.hpp
@@ -9,9 +9,9 @@
 #define NT2_EXPONENTIAL_FUNCTIONS_GENERIC_EXPRECNEG_HPP_INCLUDED
 
 #include <nt2/exponential/functions/exprecneg.hpp>
-#include <nt2/include/functions/exp.hpp>
-#include <nt2/include/functions/rec.hpp>
-#include <nt2/include/functions/unary_minus.hpp>
+#include <nt2/include/functions/simd/exp.hpp>
+#include <nt2/include/functions/simd/rec.hpp>
+#include <nt2/include/functions/simd/unary_minus.hpp>
 
 namespace nt2 {
   namespace ext {

--- a/modules/core/exponential/include/nt2/exponential/functions/generic/exprecneg.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/generic/exprecneg.hpp
@@ -1,0 +1,32 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_EXPONENTIAL_FUNCTIONS_GENERIC_EXPRECNEG_HPP_INCLUDED
+#define NT2_EXPONENTIAL_FUNCTIONS_GENERIC_EXPRECNEG_HPP_INCLUDED
+
+#include <nt2/exponential/functions/exprecneg.hpp>
+#include <nt2/include/functions/exp.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/unary_minus.hpp>
+
+namespace nt2 {
+  namespace ext {
+    BOOST_DISPATCH_IMPLEMENT  ( exprecneg_, tag::cpu_
+                                , (A0)
+                                , (generic_< floating_<A0> >)
+                              )
+    {
+      typedef A0 result_type;
+      NT2_FUNCTOR_CALL(1)
+      {
+        return exp(-rec(a0));
+      }
+    };
+  }
+}
+
+#endif

--- a/modules/core/exponential/include/nt2/exponential/functions/generic/exprecnegc.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/generic/exprecnegc.hpp
@@ -1,0 +1,32 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_EXPONENTIAL_FUNCTIONS_GENERIC_EXPRECNEGC_HPP_INCLUDED
+#define NT2_EXPONENTIAL_FUNCTIONS_GENERIC_EXPRECNEGC_HPP_INCLUDED
+
+#include <nt2/exponential/functions/exprecnegc.hpp>
+#include <nt2/include/functions/expm1.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/unary_minus.hpp>
+
+namespace nt2 {
+  namespace ext {
+    BOOST_DISPATCH_IMPLEMENT  ( exprecnegc_, tag::cpu_
+                                , (A0)
+                                , (generic_< floating_<A0> >)
+                              )
+    {
+      typedef A0 result_type;
+      NT2_FUNCTOR_CALL(1)
+      {
+        return -expm1(-rec(a0));
+      }
+    };
+  }
+}
+
+#endif

--- a/modules/core/exponential/include/nt2/exponential/functions/generic/exprecnegc.hpp
+++ b/modules/core/exponential/include/nt2/exponential/functions/generic/exprecnegc.hpp
@@ -9,9 +9,9 @@
 #define NT2_EXPONENTIAL_FUNCTIONS_GENERIC_EXPRECNEGC_HPP_INCLUDED
 
 #include <nt2/exponential/functions/exprecnegc.hpp>
-#include <nt2/include/functions/expm1.hpp>
-#include <nt2/include/functions/rec.hpp>
-#include <nt2/include/functions/unary_minus.hpp>
+#include <nt2/include/functions/simd/expm1.hpp>
+#include <nt2/include/functions/simd/rec.hpp>
+#include <nt2/include/functions/simd/unary_minus.hpp>
 
 namespace nt2 {
   namespace ext {

--- a/modules/core/exponential/unit/scalar/CMakeLists.txt
+++ b/modules/core/exponential/unit/scalar/CMakeLists.txt
@@ -14,6 +14,8 @@ SET( SOURCES
   expx2.cpp
   exp10.cpp
   exp2.cpp
+  exprecneg.cpp
+  exprecnegc.cpp
   log.cpp
   log1p.cpp
   log10.cpp

--- a/modules/core/exponential/unit/scalar/exprecneg.cpp
+++ b/modules/core/exponential/unit/scalar/exprecneg.cpp
@@ -1,0 +1,49 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/exprecneg.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/sdk/meta/as_floating.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/mzero.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+#include <nt2/include/constants/exp_1.hpp>
+
+NT2_TEST_CASE_TPL ( exprecneg,  NT2_REAL_TYPES)
+{
+  using nt2::exprecneg;
+  using nt2::tag::exprecneg_;
+
+  typedef typename nt2::meta::call<exprecneg_(T)>::type r_t;
+  typedef T wished_r_t;
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Inf<T>()), nt2::One<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Minf<T>()), nt2::One<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Nan<T>()), nt2::Nan<r_t>(), 0.75);
+#endif
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Mone<T>()),nt2::Exp_1<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::One<T>()), nt2::rec(nt2::Exp_1<r_t>()), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Zero<T>()), nt2::Zero<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Mzero<T>()), nt2::Inf<r_t>(), 0.75);
+}

--- a/modules/core/exponential/unit/scalar/exprecnegc.cpp
+++ b/modules/core/exponential/unit/scalar/exprecnegc.cpp
@@ -1,0 +1,52 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/exprecnegc.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/sdk/meta/as_floating.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/oneminus.hpp>
+#include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/mzero.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+#include <nt2/include/constants/exp_1.hpp>
+
+NT2_TEST_CASE_TPL ( exprecnegc,  NT2_REAL_TYPES)
+{
+  using nt2::exprecnegc;
+  using nt2::tag::exprecnegc_;
+
+  typedef typename nt2::meta::call<exprecnegc_(T)>::type r_t;
+  typedef T wished_r_t;
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Inf<T>()), nt2::Zero<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Minf<T>()), nt2::Zero<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Nan<T>()), nt2::Nan<r_t>(), 0.75);
+#endif
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Mone<T>()),
+                     nt2::oneminus(nt2::Exp_1<r_t>()),0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::One<T>()),
+                     nt2::oneminus(nt2::rec(nt2::Exp_1<r_t>())), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Zero<T>()), nt2::One<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Mzero<T>()), nt2::Minf<r_t>(), 0.75);
+}

--- a/modules/core/exponential/unit/simd/CMakeLists.txt
+++ b/modules/core/exponential/unit/simd/CMakeLists.txt
@@ -22,6 +22,8 @@ SET( SOURCES
   exp2.cpp
   exp10.cpp
   exp.cpp
+  exprecneg.cpp
+  exprecnegc.cpp
   cbrt.cpp
   realsqrt.cpp
   reallog.cpp

--- a/modules/core/exponential/unit/simd/exprecneg.cpp
+++ b/modules/core/exponential/unit/simd/exprecneg.cpp
@@ -1,0 +1,52 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/exprecneg.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/sdk/meta/as_floating.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/mzero.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+#include <nt2/include/constants/exp_1.hpp>
+
+NT2_TEST_CASE_TPL ( exprecneg,  NT2_SIMD_REAL_TYPES)
+{
+  using nt2::exprecneg;
+  using nt2::tag::exprecneg_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+
+  typedef typename nt2::meta::call<exprecneg_(vT)>::type r_t;
+  typedef vT wished_r_t;
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Inf<vT>()), nt2::One<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Minf<vT>()), nt2::One<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Nan<vT>()), nt2::Nan<r_t>(), 0.75);
+#endif
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Mone<vT>()),nt2::Exp_1<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::One<vT>()), nt2::rec(nt2::Exp_1<r_t>()), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Zero<vT>()), nt2::Zero<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecneg(nt2::Mzero<vT>()), nt2::Inf<r_t>(), 0.75);
+}

--- a/modules/core/exponential/unit/simd/exprecnegc.cpp
+++ b/modules/core/exponential/unit/simd/exprecnegc.cpp
@@ -1,0 +1,54 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/exponential/include/functions/exprecnegc.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/sdk/meta/as_floating.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/mone.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/mzero.hpp>
+#include <nt2/include/constants/inf.hpp>
+#include <nt2/include/constants/minf.hpp>
+#include <nt2/include/constants/nan.hpp>
+#include <nt2/include/constants/exp_1.hpp>
+
+NT2_TEST_CASE_TPL ( exprecnegc,  NT2_SIMD_REAL_TYPES)
+{
+  using nt2::exprecnegc;
+  using nt2::tag::exprecnegc_;
+  using boost::simd::native;
+  typedef BOOST_SIMD_DEFAULT_EXTENSION  ext_t;
+  typedef native<T,ext_t>                  vT;
+
+  typedef typename nt2::meta::call<exprecnegc_(vT)>::type r_t;
+  typedef vT wished_r_t;
+
+  // return type conformity test
+  NT2_TEST_TYPE_IS(r_t, wished_r_t);
+
+  // specific values tests
+#ifndef BOOST_SIMD_NO_INVALIDS
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Inf<vT>()), nt2::Zero<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Minf<vT>()), nt2::Zero<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Nan<vT>()), nt2::Nan<r_t>(), 0.75);
+#endif
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Mone<vT>()),
+                     nt2::oneminus(nt2::Exp_1<r_t>()),0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::One<vT>()),
+                     nt2::oneminus(nt2::rec(nt2::Exp_1<r_t>())), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Zero<vT>()), nt2::One<r_t>(), 0.75);
+  NT2_TEST_ULP_EQUAL(exprecnegc(nt2::Mzero<vT>()), nt2::Minf<r_t>(), 0.75);
+}


### PR DESCRIPTION
...c (c for complementary)

The complementary is written with expm1 to ensure accuracy
This is mainly sugar as no optimization is at sight.