### PR TITLE
hess ishess and lapack gghrd used in hess

### DIFF
--- a/modules/core/base/include/nt2/predicates/functions/ishess.hpp
+++ b/modules/core/base/include/nt2/predicates/functions/ishess.hpp
@@ -1,0 +1,55 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_PREDICATES_FUNCTIONS_ISHESS_HPP_INCLUDED
+#define NT2_PREDICATES_FUNCTIONS_ISHESS_HPP_INCLUDED
+
+/*!
+  @file
+  @brief Defines the ishess function
+**/
+
+#include <nt2/include/functor.hpp>
+
+namespace nt2 {
+  namespace tag {
+    /*!
+      @brief Tag for ishess functor
+    **/
+    struct ishess_ : ext::abstract_<ishess_>
+    {
+      typedef ext::abstract_<ishess_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_ishess_( ext::adl_helper(),
+                                static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::ishess_, Site> dispatching_ishess_
+    (adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::ishess_, Site>();
+    }
+    template<class... Args>
+    struct impl_ishess_;
+  }
+
+  /*!
+    @brief is a matrix in hessenberg form
+
+    A matrix is in hessenberg form if it is zero below the first subdiagonal.
+
+    @param a
+
+    @return a bool
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(nt2::tag::ishess_, ishess, 1)
+}
+
+#endif

--- a/modules/core/base/include/nt2/predicates/functions/scalar/ishess.hpp
+++ b/modules/core/base/include/nt2/predicates/functions/scalar/ishess.hpp
@@ -1,0 +1,26 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_PREDICATES_FUNCTIONS_SCALAR_ISHESS_HPP_INCLUDED
+#define NT2_PREDICATES_FUNCTIONS_SCALAR_ISHESS_HPP_INCLUDED
+
+#include <nt2/predicates/functions/ishess.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( ishess_, tag::cpu_
+                            , (A0)
+                            , (scalar_< unspecified_<A0> >)
+                            )
+  {
+    typedef bool result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const A0&) const { return true; }
+  };
+} }
+
+#endif

--- a/modules/core/container/table/include/nt2/predicates/functions/table/ishess.hpp
+++ b/modules/core/container/table/include/nt2/predicates/functions/table/ishess.hpp
@@ -1,0 +1,40 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_PREDICATES_FUNCTIONS_TABLE_ISHESS_HPP_INCLUDED
+#define NT2_PREDICATES_FUNCTIONS_TABLE_ISHESS_HPP_INCLUDED
+
+#include <nt2/predicates/functions/ishess.hpp>
+#include <nt2/include/functions/last_index.hpp>
+#include <nt2/include/functions/first_index.hpp>
+#include <nt2/include/functions/is_nez.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( ishess_, tag::cpu_
+                              , (A0)
+                              , ((ast_<A0, nt2::container::domain>))
+                            )
+  {
+    typedef bool result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const A0& a0) const
+    {
+      for(std::ptrdiff_t j=first_index<2>(a0); j <= last_index<2>(a0) ; ++j)
+      {
+        for(std::ptrdiff_t i=j+2; i <= last_index<1>(a0) ; ++i)
+        {
+          if(is_nez(a0(i, j))) return false;
+        }
+      }
+      return true;
+    }
+  };
+} }
+
+#endif

--- a/modules/core/container/table/unit/predicates/CMakeLists.txt
+++ b/modules/core/container/table/unit/predicates/CMakeLists.txt
@@ -19,6 +19,7 @@ SET( SOURCES
   isexpandable_to.cpp
   isfloating.cpp
   ishermitian.cpp
+  ishess.cpp
   isinside.cpp
   isinteger.cpp
   ismatrix.cpp

--- a/modules/core/container/table/unit/predicates/ishess.cpp
+++ b/modules/core/container/table/unit/predicates/ishess.cpp
@@ -1,0 +1,43 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/table.hpp>
+#include <nt2/include/functions/ishess.hpp>
+#include <nt2/include/functions/ones.hpp>
+#include <nt2/include/functions/triu.hpp>
+#include <nt2/include/functions/tril.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/basic.hpp>
+
+NT2_TEST_CASE( fundamental_ishess )
+{
+  NT2_TEST( nt2::ishess('e') );
+  NT2_TEST( nt2::ishess(1)   );
+  NT2_TEST( nt2::ishess(1.)  );
+  NT2_TEST( nt2::ishess(1.f) );
+}
+
+NT2_TEST_CASE( table_ishess )
+{
+  nt2::table<float> a(nt2::of_size(3, 4));
+
+  for(std::ptrdiff_t j=1; j <= 4; j++)
+    for(std::ptrdiff_t i=1; i <= 3; i++)
+      a(i, j) = (i <= j+1) ? (i+j) : 0;
+
+  NT2_TEST( nt2::ishess(a) );
+
+  a(3,1) = 25;
+  NT2_TEST( !nt2::ishess(a) );
+
+  for(std::ptrdiff_t j=1; j <= 4; j++)
+    for(std::ptrdiff_t i=1; i <= 3; i++)
+      a(i, j) = (i >=  j) ? (i+j) : 0;
+
+  NT2_TEST( !nt2::ishess(a) );
+}
+

--- a/modules/core/linalg/include/nt2/linalg/details/lapack/declare/gghrd.hpp
+++ b/modules/core/linalg/include/nt2/linalg/details/lapack/declare/gghrd.hpp
@@ -1,0 +1,152 @@
+//==============================================================================
+//         Copyright 2015 - Jean-Thierry Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_DETAILS_LAPACK_DECLARE_GGHRD_HPP_INCLUDED
+#define NT2_LINALG_DETAILS_LAPACK_DECLARE_GGHRD_HPP_INCLUDED
+#include <nt2/linalg/details/utility/f77_wrapper.hpp>
+
+/// Lapack declaration interface
+///
+/// excerpt from LAPACK documentation
+// /// FOR ? C or Z
+// *  ?GGHRD reduces a pair of complex matrices (A,B) to generalized upper
+// *  Hessenberg form using unitary transformations, where A is a
+// *  general matrix and B is upper triangular.  The form of the generalized
+// *  eigenvalue problem is
+// *     A*x = lambda*B*x,
+// *  and B is typically made upper triangular by computing its QR
+// *  factorization and moving the unitary matrix Q to the left side
+// *  of the equation.
+// *
+// *  This subroutine simultaneously reduces A to a Hessenberg matrix H:
+// *     Q**H*A*Z = H
+// *  and transforms B to another upper triangular matrix T:
+// *     Q**H*B*Z = T
+// *  in order to reduce the problem to its standard form
+// *     H*y = lambda*T*y
+// *  where y = Z**H*x.
+// *
+// *  The unitary matrices Q and Z are determined as products of Givens
+// *  rotations.  They may either be formed explicitly, or they may be
+// *  postmultiplied into input matrices Q1 and Z1, so that
+// *       Q1 * A * Z1**H = (Q1*Q) * H * (Z1*Z)**H
+// *       Q1 * B * Z1**H = (Q1*Q) * T * (Z1*Z)**H
+// *  If Q1 is the unitary matrix from the QR factorization of B in the
+// *  original equation A*x = lambda*B*x, then CGGHRD reduces the original
+// *  problem to generalized Hessenberg form.
+// *
+// *  Arguments
+// *  =========
+// *
+// *  COMPQ   (input) CHARACTER*1
+// *          = 'N': do not compute Q;
+// *          = 'I': Q is initialized to the unit matrix, and the
+// *                 unitary matrix Q is returned;
+// *          = 'V': Q must contain a unitary matrix Q1 on entry,
+// *                 and the product Q1*Q is returned.
+// *
+// *  COMPZ   (input) CHARACTER*1
+// *          = 'N': do not compute Q;
+// *          = 'I': Q is initialized to the unit matrix, and the
+// *                 unitary matrix Q is returned;
+// *          = 'V': Q must contain a unitary matrix Q1 on entry,
+// *                 and the product Q1*Q is returned.
+// *
+// *  N       (input) INTEGER
+// *          The order of the matrices A and B.  N >= 0.
+// *
+// *  ILO     (input) INTEGER
+// *  IHI     (input) INTEGER
+// *          ILO and IHI mark the rows and columns of A which are to be
+// *          reduced.  It is assumed that A is already upper triangular
+// *          in rows and columns 1:ILO-1 and IHI+1:N.  ILO and IHI are
+// *          normally set by a previous call to CGGBAL; otherwise they
+// *          should be set to 1 and N respectively.
+// *          1 <= ILO <= IHI <= N, if N > 0; ILO=1 and IHI=0, if N=0.
+// *
+// *  A       (input/output)  array, dimension (LDA, N)
+// *          On entry, the N-by-N general matrix to be reduced.
+// *          On exit, the upper triangle and the first subdiagonal of A
+// *          are overwritten with the upper Hessenberg matrix H, and the
+// *          rest is set to zero.
+// *
+// *  LDA     (input) INTEGER
+// *          The leading dimension of the array A.  LDA >= max(1,N).
+// *
+// *  B       (input/output)  array, dimension (LDB, N)
+// *          On entry, the N-by-N upper triangular matrix B.
+// *          On exit, the upper triangular matrix T = Q**H B Z.  The
+// *          elements below the diagonal are set to zero.
+// *
+// *  LDB     (input) INTEGER
+// *          The leading dimension of the array B.  LDB >= max(1,N).
+// *
+// *  Q       (input/output)  array, dimension (LDQ, N)
+// *          On entry, if COMPQ = 'V', the unitary matrix Q1, typically
+// *          from the QR factorization of B.
+// *          On exit, if COMPQ='I', the unitary matrix Q, and if
+// *          COMPQ = 'V', the product Q1*Q.
+// *          Not referenced if COMPQ='N'.
+// *
+// *  LDQ     (input) INTEGER
+// *          The leading dimension of the array Q.
+// *          LDQ >= N if COMPQ='V' or 'I'; LDQ >= 1 otherwise.
+// *
+// *  Z       (input/output)  array, dimension (LDZ, N)
+// *          On entry, if COMPZ = 'V', the unitary matrix Z1.
+// *          On exit, if COMPZ='I', the unitary matrix Z, and if
+// *          COMPZ = 'V', the product Z1*Z.
+// *          Not referenced if COMPZ='N'.
+// *
+// *  LDZ     (input) INTEGER
+// *          The leading dimension of the array Z.
+// *          LDZ >= N if COMPZ='V' or 'I'; LDZ >= 1 otherwise.
+// *
+// *  INFO    (output) INTEGER
+// *          = 0:  successful exit.
+// *          < 0:  if INFO = -i, the i-th argument had an illegal value.
+// *
+extern "C"
+
+{
+  void NT2_F77NAME(dgghrd)( const char* compq,   const char* compz
+                          , const nt2_la_int* n , const nt2_la_int* ilo, const nt2_la_int* ihi
+                          , double* a,  const nt2_la_int* lda
+                          , double* b,  const nt2_la_int* ldb
+                          , double* q,  const nt2_la_int* ldq
+                          , double* z,  const nt2_la_int* ldz
+                          , nt2_la_int* info
+                          );
+  void NT2_F77NAME(sgghrd)( const char* compq,   const char* compz
+                          , const nt2_la_int* n , const nt2_la_int* ilo, const nt2_la_int* ihi
+                          , float* a,  const nt2_la_int* lda
+                          , float* b,  const nt2_la_int* ldb
+                          , float* q,  const nt2_la_int* ldq
+                          , float* z,  const nt2_la_int* ldz
+                          , nt2_la_int* info
+                          );
+  void NT2_F77NAME(cgghrd)( const char* compq,   const char* compz
+                          ,  const nt2_la_int* n , const nt2_la_int* ilo, const nt2_la_int* ihi
+                          , nt2_la_complex* a,  const nt2_la_int* lda
+                          , nt2_la_complex* b,  const nt2_la_int* ldb
+                          , nt2_la_complex* q,  const nt2_la_int* ldq
+                          , nt2_la_complex* z,  const nt2_la_int* ldz
+                          , nt2_la_int* info
+                          );
+  void NT2_F77NAME(zgghrd)( const char* compq,   const char* compz
+                          , const nt2_la_int* n , const nt2_la_int* ilo, const nt2_la_int* ihi
+                          , nt2_la_complex* a,  const nt2_la_int* lda
+                          , nt2_la_complex* b,  const nt2_la_int* ldb
+                          , nt2_la_complex* q,  const nt2_la_int* ldq
+                          , nt2_la_complex* z,  const nt2_la_int* ldz
+                          , nt2_la_int* info
+                          );
+
+
+}
+
+#endif

--- a/modules/core/linalg/include/nt2/linalg/functions/factorizations/hess.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/factorizations/hess.hpp
@@ -1,0 +1,221 @@
+//==============================================================================
+//          Copyright 2015 - Jean-Thierry Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_FUNCTIONS_FACTORIZATIONS_HESS_HPP_INCLUDED
+#define NT2_LINALG_FUNCTIONS_FACTORIZATIONS_HESS_HPP_INCLUDED
+
+#include <nt2/linalg/functions/hess.hpp>
+#include <nt2/include/functions/ctranspose.hpp>
+#include <nt2/include/functions/gghrd.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/istriu.hpp>
+#include <nt2/include/functions/issquare.hpp>
+#include <nt2/include/functions/qr.hpp>
+#include <nt2/include/functions/resize.hpp>
+#include <nt2/include/functions/tie.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/core/container/table/table.hpp>
+#include <nt2/core/container/dsl/as_terminal.hpp>
+#include <nt2/core/utility/assign_swap.hpp>
+#include <boost/dispatch/attributes.hpp>
+#include <boost/assert.hpp>
+
+namespace nt2 { namespace ext
+{
+  //============================================================================
+  //hess Scalar
+  //============================================================================
+  BOOST_DISPATCH_IMPLEMENT  ( hess_, tag::cpu_
+                            , (A0)
+                            , (scalar_<unspecified_<A0> >)
+                            )
+  {
+    typedef A0 result_type;
+
+    BOOST_FORCEINLINE result_type operator()(const A0& a0) const
+    {
+      return a0;
+    }
+  };
+
+  //============================================================================
+  //hess Scalar
+  //============================================================================
+  BOOST_DISPATCH_IMPLEMENT  ( hess_, tag::cpu_
+                            , (A0)(A1)
+                            , (scalar_<unspecified_<A0> >)
+                              (scalar_<unspecified_<A1> >)
+                            )
+  {
+    typedef A0 result_type;
+
+    BOOST_FORCEINLINE result_type operator()(const A0& a0, const A1&) const
+    {
+      return a0;
+    }
+  };
+
+  //============================================================================
+  //hess
+  //============================================================================
+  /// INTERNAL ONLY
+  BOOST_DISPATCH_IMPLEMENT  ( hess_, tag::cpu_
+                            , (A0)(N0)(A1)(N1)
+                            , ((node_ < A0, nt2::tag::hess_
+                                      , N0, nt2::container::domain
+                                      >
+                              ))
+                              ((node_ < A1, nt2::tag::tie_
+                                      , N1, nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef void                                                        result_type;
+    typedef typename boost::proto::result_of::child_c<A0&,0>::value_type     child0;
+    typedef typename child0::value_type                                      type_t;
+    typedef nt2::memory::container<tag::table_, type_t, nt2::_2D>        o_semantic;
+
+    BOOST_FORCEINLINE result_type operator()( A0& a0, A1& a1 ) const
+    {
+      BOOST_ASSERT_MSG(issquare(boost::proto::child_c<0>(a0))
+                      , "input matrices must be square");
+      eval(a0, a1, N0(), N1());
+    }
+  private:
+    /// INTERNAL ONLY - h =  hess(a)
+    BOOST_FORCEINLINE
+    void eval ( A0& a0, A1& a1
+              , boost::mpl::long_<1> const& // # inputs
+              , boost::mpl::long_<1> const& // # outputs
+              ) const
+    {
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , hess, boost::proto::child_c<0>(a0)
+                           , boost::proto::child_c<0>(a1));
+      nt2_la_int n = height(hess);
+      nt2::container::table<type_t> b = eye(n, meta::as_<type_t>());
+      nt2::gghrd( 'N', 'N', 1, n
+                , boost::proto::value(hess), boost::proto::value(b)
+                , boost::proto::value(b),    boost::proto::value(b));
+      assign_swap(boost::proto::child_c<0>(a1), hess);
+    }
+
+    /// INTERNAL ONLY - tie(h, p) =  hess(a)
+    BOOST_FORCEINLINE
+    void eval ( A0& a0, A1& a1
+              , boost::mpl::long_<1> const& // # inputs
+              , boost::mpl::long_<2> const& // # outputs
+              ) const
+    {
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , hess, boost::proto::child_c<0>(a0)
+                           , boost::proto::child_c<0>(a1));
+      NT2_AS_TERMINAL_OUT(o_semantic
+                           , p
+                           , boost::proto::child_c<1>(a1));
+      nt2_la_int n = height(hess);
+      nt2::container::table<type_t> b = eye(n, meta::as_<type_t>());
+      p.resize(hess.extent());
+      nt2::gghrd( 'I', 'N', 1, n
+                , boost::proto::value(hess), boost::proto::value(b)
+                , boost::proto::value(p),    boost::proto::value(b));
+      assign_swap(boost::proto::child_c<0>(a1), hess);
+      assign_swap(boost::proto::child_c<1>(a1), p);
+    }
+
+    /// INTERNAL ONLY - tie(aa, bb, q, z) =  hess(a)
+    BOOST_FORCEINLINE
+    void eval ( A0& a0, A1& a1
+              , boost::mpl::long_<2> const& // # inputs
+              , boost::mpl::long_<4> const& // # outputs
+              ) const
+    {
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , aa, boost::proto::child_c<0>(a0)
+                           , boost::proto::child_c<0>(a1));
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , bb, boost::proto::child_c<1>(a0)
+                           , boost::proto::child_c<1>(a1));
+      BOOST_ASSERT_MSG(issquare(bb), "input matrices must be square");
+      nt2_la_int n = height(aa);
+      nt2::container::table<type_t> q;
+      nt2::container::table<type_t> z;
+      if(!istriu(bb))
+      {
+        tie(q, bb) = qr(bb);
+        aa = mtimes(ctrans(q), aa);
+      }
+      nt2::gghrd( 'V', 'I', 1, n
+                , boost::proto::value(aa), boost::proto::value(bb)
+                , boost::proto::value(q) , boost::proto::value(z));
+      assign_swap(boost::proto::child_c<0>(a1), aa);
+      assign_swap(boost::proto::child_c<1>(a1), bb);
+      assign_swap(boost::proto::child_c<2>(a1), q);
+      assign_swap(boost::proto::child_c<3>(a1), z);
+    }
+
+    /// INTERNAL ONLY - tie(aa, bb, q, z) =  hess(a)
+    BOOST_FORCEINLINE
+    void eval ( A0& a0, A1& a1
+              , boost::mpl::long_<2> const& // # inputs
+              , boost::mpl::long_<3> const& // # outputs
+              ) const
+    {
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , aa, boost::proto::child_c<0>(a0)
+                           , boost::proto::child_c<0>(a1));
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , bb, boost::proto::child_c<1>(a0)
+                           , boost::proto::child_c<1>(a1));
+      BOOST_ASSERT_MSG(issquare(bb), "input matrices must be square");
+      nt2_la_int n = height(aa);
+      nt2::container::table<type_t> q;
+      if(!istriu(bb))
+      {
+        tie(q, bb) = qr(bb);
+        aa = mtimes(trans(q), aa);
+      }
+      nt2::gghrd( 'V', 'N', 1, n
+                , boost::proto::value(aa), boost::proto::value(bb)
+                , boost::proto::value(q) , boost::proto::value(q));
+      assign_swap(boost::proto::child_c<0>(a1), aa);
+      assign_swap(boost::proto::child_c<1>(a1), bb);
+      assign_swap(boost::proto::child_c<2>(a1), q);
+    }
+
+    /// INTERNAL ONLY - tie(aa, bb, q, z) =  hess(a)
+    BOOST_FORCEINLINE
+    void eval ( A0& a0, A1& a1
+              , boost::mpl::long_<2> const& // # inputs
+              , boost::mpl::long_<2> const& // # outputs
+              ) const
+    {
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , aa, boost::proto::child_c<0>(a0)
+                           , boost::proto::child_c<0>(a1));
+      NT2_AS_TERMINAL_INOUT(o_semantic
+                           , bb, boost::proto::child_c<1>(a0)
+                           , boost::proto::child_c<1>(a1));
+      BOOST_ASSERT_MSG(issquare(bb), "input matrices must be square");
+      nt2_la_int n = height(aa);
+      if(!istriu(bb))
+      {
+        nt2::container::table<type_t> q;
+        tie(q, bb) = qr(bb);
+        aa = mtimes(trans(q), aa);
+      }
+      nt2::gghrd( 'N', 'N', 1, n
+                , boost::proto::value(aa), boost::proto::value(bb)
+                , boost::proto::value(bb), boost::proto::value(bb));
+      assign_swap(boost::proto::child_c<0>(a1), aa);
+      assign_swap(boost::proto::child_c<1>(a1), bb);
+    }
+  };
+} }
+
+#endif

--- a/modules/core/linalg/include/nt2/linalg/functions/gghrd.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/gghrd.hpp
@@ -1,0 +1,58 @@
+//==============================================================================
+//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_FUNCTIONS_GGHRD_HPP_INCLUDED
+#define NT2_LINALG_FUNCTIONS_GGHRD_HPP_INCLUDED
+
+/*!
+  @file
+  @brief Defines and implements gghrd function
+**/
+
+#include <nt2/include/functor.hpp>
+
+namespace nt2
+{
+  namespace tag
+  {
+    /// @brief Defines trf function tag
+    struct gghrd_ : ext::abstract_<gghrd_>
+    {
+      /// INTERNAL ONLY
+      typedef ext::abstract_<gghrd_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_gghrd_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::gghrd_, Site> dispatching_gghrd_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::gghrd_, Site>();
+    }
+    template<class... Args>
+    struct impl_gghrd_;
+  }
+
+  /*!
+    @brief
+
+    @param
+    @param
+
+    @return
+  **/
+  NT2_FUNCTION_IMPLEMENTATION_TPL (tag::gghrd_, gghrd
+                                  , (const A0&)(const A1&)(const A2&)(const A3&)(A4&)(A5&)(A6&)(A7&)
+                                  , 8
+                                  );
+}
+
+#endif

--- a/modules/core/linalg/include/nt2/linalg/functions/hess.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/hess.hpp
@@ -1,0 +1,79 @@
+//==============================================================================
+//         Copyright 2014 - Jean-Thierry Lapresté
+//         Copyright 2003 - 2013   LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_FUNCTIONS_HESS_HPP_INCLUDED
+#define NT2_LINALG_FUNCTIONS_HESS_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/size_as.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/sdk/meta/tieable_hierarchy.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+namespace nt2
+{
+  namespace tag
+  {
+    struct hess_ : ext::tieable_<hess_>
+    {
+      typedef ext::tieable_<hess_>  parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_hess_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::hess_, Site> dispatching_hess_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::hess_, Site>();
+    }
+    template<class... Args>
+    struct impl_hess_;
+  }
+
+  /**
+     @brief the hess functor finds  the Hessenberg form of matrix a.
+
+     h = hess(a)
+
+     tie(h, q) = hess(a)
+
+     tie(aa, bb{, q{, z}}) = hess(a, b)
+
+     tie(h, q) = hess(a) produces a hessenberg matrix h and a unitary matrix p
+     so that a = mtimes(mtimes(q, h), ctrans(q)).
+
+     tie(h, r, q, z) = hess(a, b) produces an upper hessenberg matrix h,
+     an upper triangular matrix r, and unitary matrices q and z such that
+     mtimes(mtimes(q, h), ctrans(z)) = a and mtimes(mtimes(q, r, ctrans(z)) = b.
+
+     Note : Be aware that are not exactly the Matlab outputs.
+
+     The hessenberg form of a matrix is zero below the first subdiagonal.
+     If the matrix is symmetric or hermitian, the form is tridiagonal.
+
+     hess can transform a general eigenvalue problem ax = lbx in hx = lrx,
+     where h is hessenberg and r triangular.
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::hess_, hess, 1)
+  NT2_FUNCTION_IMPLEMENTATION(tag::hess_, hess, 2)
+}
+
+namespace nt2 { namespace ext
+{
+  template<class Domain, int N, class Expr>
+  struct  size_of<tag::hess_,Domain,N,Expr>
+        : meta::size_as<Expr,0>
+  {};
+} }
+
+#endif

--- a/modules/core/linalg/include/nt2/linalg/functions/lapack/general/gghrd.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/lapack/general/gghrd.hpp
@@ -1,0 +1,186 @@
+//==============================================================================
+//         Copyright 2015  J.T. Lapreste
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_FUNCTIONS_LAPACK_GENERAL_GGHRD_HPP_INCLUDED
+#define NT2_LINALG_FUNCTIONS_LAPACK_GENERAL_GGHRD_HPP_INCLUDED
+
+#include <nt2/linalg/functions/gghrd.hpp>
+#include <nt2/linalg/details/lapack/declare/gghrd.hpp>
+#include <nt2/linalg/details/utility/f77_wrapper.hpp>
+
+#include <nt2/include/functions/of_size.hpp>
+#include <nt2/include/functions/resize.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/max.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( gghrd_, tag::cpu_
+                            , (COMPQ)(COMPZ)(ILO)(IHI)(A)(S0)(B)(S1)(Q)(S2)(Z)(S3)
+                            , (scalar_< ints8_<COMPQ> >)
+                              (scalar_< ints8_<COMPZ> >)
+                              (scalar_< integer_<ILO>>)
+                              (scalar_< integer_<IHI>>)
+                              ((container_< nt2::tag::table_, double_<A>, S0 >))
+                              ((container_< nt2::tag::table_, double_<B>, S1 >))
+                              ((container_< nt2::tag::table_, double_<Q>, S2 >))
+                              ((container_< nt2::tag::table_, double_<Z>, S3 >))
+                            )
+  {
+     typedef nt2_la_int result_type;
+     typedef typename A::value_type type_t;
+     BOOST_FORCEINLINE result_type operator()(COMPQ const &compq,  COMPZ const & compz
+                                             , ILO const & il, IHI const & ih
+                                            ,  A& a, B& b, Q& q, Z& z) const
+     {
+        result_type that;
+        nt2_la_int  n  = nt2::height(a);
+        if(compq == 'i' || compq == 'I') q.resize(of_size(n,n));
+        if(compz == 'i' || compz == 'I') z.resize(of_size(n,n));
+        nt2_la_int  lda = nt2::max(a.leading_size(), One<size_t>());
+        nt2_la_int  ldb = nt2::max(b.leading_size(), One<size_t>());
+        nt2_la_int  ldq = nt2::max(q.leading_size(), One<size_t>());
+        nt2_la_int  ldz = nt2::max(z.leading_size(), One<size_t>());
+        nt2_la_int  ilo = il;
+        nt2_la_int  ihi = ih;
+
+        NT2_F77NAME(dgghrd)(&compq, &compz, &n
+                           , &ilo, &ihi
+                           , a.data(), &lda
+                           , b.data(), &ldb
+                           , q.data(), &ldq
+                           , z.data(), &ldz,
+                            &that);
+
+        return that;
+     }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( gghrd_, tag::cpu_
+                            , (COMPQ)(COMPZ)(ILO)(IHI)(A)(S0)(B)(S1)(Q)(S2)(Z)(S3)
+                            , (scalar_< ints8_<COMPQ> >)
+                              (scalar_< ints8_<COMPZ> >)
+                              (scalar_< integer_<ILO>>)
+                              (scalar_< integer_<IHI>>)
+                              ((container_< nt2::tag::table_, single_<A>, S0 >))
+                              ((container_< nt2::tag::table_, single_<B>, S1 >))
+                              ((container_< nt2::tag::table_, single_<Q>, S2 >))
+                              ((container_< nt2::tag::table_, single_<Z>, S3 >))
+                            )
+  {
+     typedef nt2_la_int result_type;
+     typedef  typename A::value_type type_t;
+     BOOST_FORCEINLINE result_type operator()(COMPQ const &compq,  COMPZ const & compz
+                                             , ILO const & il, IHI const & ih
+                                            ,  A& a, B& b, Q& q, Z& z) const
+     {
+        result_type that;
+        nt2_la_int  n  = nt2::height(a);
+        if(compq == 'i' || compq == 'I') q.resize(of_size(n,n));
+        if(compz == 'i' || compz == 'I') z.resize(of_size(n,n));
+        nt2_la_int  lda = nt2::max(a.leading_size(), One<size_t>());
+        nt2_la_int  ldb = nt2::max(b.leading_size(), One<size_t>());
+        nt2_la_int  ldq = nt2::max(q.leading_size(), One<size_t>());
+        nt2_la_int  ldz = nt2::max(z.leading_size(), One<size_t>());
+        nt2_la_int  ilo = il;
+        nt2_la_int  ihi = ih;
+        NT2_F77NAME(sgghrd)(&compq, &compz, &n
+                           , &ilo, &ihi
+                           , a.data(), &lda
+                           , b.data(), &ldb
+                           , q.data(), &ldq
+                           , z.data(), &ldz,
+                            &that);
+
+        return that;
+     }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( gghrd_, tag::cpu_
+                            , (COMPQ)(COMPZ)(ILO)(IHI)(A)(S0)(B)(S1)(Q)(S2)(Z)(S3)
+                            , (scalar_< ints8_<COMPQ> >)
+                              (scalar_< ints8_<COMPZ> >)
+                              (scalar_< integer_<ILO>>)
+                              (scalar_< integer_<IHI>>)
+                              ((container_< nt2::tag::table_, complex_<single_<A>>, S0 >))
+                              ((container_< nt2::tag::table_, complex_<single_<B>>, S1 >))
+                              ((container_< nt2::tag::table_, complex_<single_<Q>>, S2 >))
+                              ((container_< nt2::tag::table_, complex_<single_<Z>>, S3 >))
+                            )
+  {
+     typedef nt2_la_int result_type;
+     typedef typename A::value_type type_t;
+     BOOST_FORCEINLINE result_type operator()(COMPQ const &compq,  COMPZ const & compz
+                                             , ILO const & il, IHI const & ih
+                                            ,  A& a, B& b, Q& q, Z& z) const
+     {
+        result_type that;
+        nt2_la_int  n  = nt2::height(a);
+        if(compq == 'i' || compq == 'I') q.resize(of_size(n,n));
+        if(compz == 'i' || compz == 'I') z.resize(of_size(n,n));
+        nt2_la_int  lda = nt2::max(a.leading_size(), One<size_t>());
+        nt2_la_int  ldb = nt2::max(b.leading_size(), One<size_t>());
+        nt2_la_int  ldq = nt2::max(q.leading_size(), One<size_t>());
+        nt2_la_int  ldz = nt2::max(z.leading_size(), One<size_t>());
+        nt2_la_int  ilo = il;
+        nt2_la_int  ihi = ih;
+
+        NT2_F77NAME(cgghrd)(&compq, &compz, &n
+                           , &ilo, &ihi
+                           , a.data(), &lda
+                           , b.data(), &ldb
+                           , q.data(), &ldq
+                           , z.data(), &ldz,
+                            &that);
+
+        return that;
+     }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( gghrd_, tag::cpu_
+                            , (COMPQ)(COMPZ)(ILO)(IHI)(A)(S0)(B)(S1)(Q)(S2)(Z)(S3)
+                            , (scalar_< ints8_<COMPQ> >)
+                              (scalar_< ints8_<COMPZ> >)
+                              (scalar_< integer_<ILO>>)
+                              (scalar_< integer_<IHI>>)
+                              ((container_< nt2::tag::table_, complex_<double_<A>>, S0 >))
+                              ((container_< nt2::tag::table_, complex_<double_<B>>, S1 >))
+                              ((container_< nt2::tag::table_, complex_<double_<Q>>, S2 >))
+                              ((container_< nt2::tag::table_, complex_<double_<Z>>, S3 >))
+                            )
+  {
+     typedef nt2_la_int result_type;
+     typedef typename A::value_type type_t;
+     BOOST_FORCEINLINE result_type operator()(COMPQ const &compq,  COMPZ const & compz
+                                             , ILO const & il, IHI const & ih
+                                            ,  A& a, B& b, Q& q, Z& z) const
+     {
+        result_type that;
+        nt2_la_int  n  = nt2::height(a);
+        if(compq == 'i' || compq == 'I') q.resize(of_size(n,n));
+        if(compz == 'i' || compz == 'I') z.resize(of_size(n,n));
+        nt2_la_int  lda = nt2::max(a.leading_size(), One<size_t>());
+        nt2_la_int  ldb = nt2::max(b.leading_size(), One<size_t>());
+        nt2_la_int  ldq = nt2::max(q.leading_size(), One<size_t>());
+        nt2_la_int  ldz = nt2::max(z.leading_size(), One<size_t>());
+        nt2_la_int  ilo = il;
+        nt2_la_int  ihi = ih;
+
+        NT2_F77NAME(zgghrd)(&compq, &compz, &n
+                           , &ilo, &ihi
+                           , a.data(), &lda
+                           , b.data(), &ldb
+                           , q.data(), &ldq
+                           , z.data(), &ldz,
+                            &that);
+
+        return that;
+     }
+  };
+
+} }
+
+#endif

--- a/modules/core/linalg/unit/factorization/CMakeLists.txt
+++ b/modules/core/linalg/unit/factorization/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 SET( SOURCES
   chol.cpp
+  hess.cpp
   lu.cpp
   schur.cpp
   svd.cpp

--- a/modules/core/linalg/unit/factorization/hess.cpp
+++ b/modules/core/linalg/unit/factorization/hess.cpp
@@ -1,0 +1,52 @@
+//==============================================================================
+//         Copyright 2015   J.T. Lapreste
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+
+#include <nt2/table.hpp>
+#include <nt2/include/functions/hess.hpp>
+#include <nt2/include/functions/tie.hpp>
+#include <nt2/include/functions/eye.hpp>
+#include <nt2/include/functions/ishess.hpp>
+#include <nt2/include/functions/istriu.hpp>
+#include <nt2/include/functions/mtimes.hpp>
+#include <nt2/include/functions/transpose.hpp>
+#include <nt2/include/functions/reshape.hpp>
+#include <nt2/include/functions/triu.hpp>
+
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/basic.hpp>
+#include <nt2/sdk/unit/tests/exceptions.hpp>
+
+NT2_TEST_CASE_TPL ( hess1,  NT2_REAL_TYPES)
+{
+  using nt2::_;
+  using nt2::meta::as_;
+
+  nt2::table<T> h, p, hess;
+  nt2::table<T> a = nt2::reshape(nt2::_(T(1), T(16)), 4, 4);
+  h = nt2::hess(a);
+  nt2::tie(h, p) = nt2::hess(a);
+  NT2_TEST(ishess(h));
+  NT2_TEST_ULP_EQUAL( a,  nt2::mtimes(p, nt2::mtimes(h, trans(p))), T(200));
+}
+
+NT2_TEST_CASE_TPL ( hess2, NT2_REAL_TYPES)
+{
+  using nt2::_;
+  using nt2::meta::as_;
+  nt2::table<T> a, b, h, r, q, z;
+  a = b =  nt2::eye(4, nt2::meta::as_<T>());
+  b(_, 1) = T(1);
+  tie(h, r, q, z) = nt2::hess(a, b);
+  NT2_TEST(ishess(h));
+  NT2_TEST(istriu(r));
+
+  NT2_TEST_ULP_EQUAL( a,  nt2::mtimes(q, nt2::mtimes(h, trans(z))), T(200));
+  NT2_TEST_ULP_EQUAL( b,  nt2::mtimes(q, nt2::mtimes(r, trans(z))), T(200));
+}
+


### PR DESCRIPTION
hess compute the hessenberg (generalzed) form of a matix
ishess test if a matix is hessenberd
gghrd is the lapack functions used to implement hess