### PR TITLE
Fix behavior w/r to Fusion 1.58 semantic change on at_c

### DIFF
--- a/modules/core/sdk/include/nt2/core/utility/of_size/fusion.hpp
+++ b/modules/core/sdk/include/nt2/core/utility/of_size/fusion.hpp
@@ -138,4 +138,12 @@ namespace boost { namespace fusion { namespace extension
   };
 } } }
 
+namespace boost { namespace fusion { namespace detail
+{
+  template <typename Sequence, typename N>
+  struct  at_impl<Sequence,N,nt2::tag::of_size_>
+        : extension::at_impl<nt2::tag::of_size_>::template apply<Sequence, N>
+  {};
+} } }
+
 #endif


### PR DESCRIPTION
at_c now checks if it's index is within fusion size. This breaks of_size as we treat it as some unbounded sequence with a size. This htofix patches the issue until 1.59 Fusion provides us with the correct traits to specialize