### PR TITLE
numerical derivatives

### DIFF
--- a/modules/core/numerical_derivatives/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/CMakeLists.txt
@@ -1,0 +1,26 @@
+##############################################################################
+###   Copyright 2015  J.T. Lapreste
+###
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+cmake_minimum_required(VERSION 2.6)
+
+if(NOT DEFINED NT2_SOURCE_ROOT AND DEFINED ENV{NT2_SOURCE_ROOT})
+  set(NT2_SOURCE_ROOT $ENV{NT2_SOURCE_ROOT})
+endif()
+if(NOT DEFINED NT2_ROOT AND DEFINED ENV{NT2_ROOT})
+  set(NT2_ROOT $ENV{NT2_ROOT})
+endif()
+if(DEFINED NT2_SOURCE_ROOT)
+  list(APPEND CMAKE_MODULE_PATH ${NT2_SOURCE_ROOT}/cmake)
+endif()
+if(DEFINED NT2_ROOT)
+  list(APPEND CMAKE_MODULE_PATH ${NT2_ROOT}/cmake)
+endif()
+
+include(NT2Module)
+nt2_module_main(core.numerical_derivatives)

--- a/modules/core/numerical_derivatives/bench/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/bench/CMakeLists.txt
@@ -1,0 +1,12 @@
+##############################################################################
+###   Copyright 2015  J.T. Lapreste
+###
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+nt2_module_use_modules(test.benchmark)
+ADD_SUBDIRECTORY(scalar)
+ADD_SUBDIRECTORY(simd)

--- a/modules/core/numerical_derivatives/bench/scalar/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/bench/scalar/CMakeLists.txt
@@ -1,0 +1,14 @@
+##############################################################################
+###   Copyright 2015  J.T. Lapreste
+###
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+SET( SOURCES
+# List of scalar test files for toolbox numerical_derivatives
+   )
+
+nt2_module_add_tests(core.numerical_derivatives.scalar.bench ${SOURCES})

--- a/modules/core/numerical_derivatives/bench/simd/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/bench/simd/CMakeLists.txt
@@ -1,0 +1,14 @@
+##############################################################################
+###   Copyright 2015  J.T. Lapreste
+###
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+SET( SOURCES
+ # List of simd test files for toolbox numerical_derivatives
+   )
+
+nt2_module_add_tests(core.numerical_derivatives.simd.bench ${SOURCES})

--- a/modules/core/numerical_derivatives/cmake/nt2.core.numerical_derivatives.dependencies.cmake
+++ b/modules/core/numerical_derivatives/cmake/nt2.core.numerical_derivatives.dependencies.cmake
@@ -1,0 +1,21 @@
+################################################################################
+#         Copyright 2003 & onward LASMEA UMR 6602 CNRS/Univ. Clermont II
+#         Copyright 2009 & onward LRI    UMR 8623 CNRS/Univ Paris Sud XI
+#
+#          Distributed under the Boost Software License, Version 1.0.
+#                 See accompanying file LICENSE.txt or copy at
+#                     http://www.boost.org/LICENSE_1_0.txt
+################################################################################
+
+SET ( NT2_CORE.NUMERICAL_DERIVATIVES_DEPENDENCIES_EXTRA
+      boost.dispatch
+      boost.simd.base
+      boost.simd.sdk
+      core.base
+      core.linalg
+      core.sdk
+      sdk.error
+      sdk.functor
+      sdk.meta
+      sdk.simd
+   )

--- a/modules/core/numerical_derivatives/doc/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/doc/CMakeLists.txt
@@ -1,0 +1,15 @@
+################################################################################
+#         Copyright 2003 & onward LASMEA UMR 6602 CNRS/Univ. Clermont II
+#         Copyright 2009 & onward LRI    UMR 8623 CNRS/Univ Paris Sud XI
+#
+#          Distributed under the Boost Software License, Version 1.0.
+#                 See accompanying file LICENSE.txt or copy at
+#                     http://www.boost.org/LICENSE_1_0.txt
+################################################################################
+
+include(nt2.doc)
+if(NOT NT2_DOCUMENTATION_ENABLED)
+  return()
+endif()
+
+nt2_module_doc(core.numerical_derivatives manual.qbk reference.doxyfile)

--- a/modules/core/numerical_derivatives/doc/manual.qbk
+++ b/modules/core/numerical_derivatives/doc/manual.qbk
@@ -1,0 +1,17 @@
+[library numerical derivatives
+  [quickbook 1.5]
+]
+
+[section Overview]
+This module provides implementation of functions allowing computation of numerical
+derivatives, gradients or jacobians by finite difference or complex-step if available.
+
+Precision is poor first derivatives are computed loosing half of the significant digits
+and second-order 3/4. You can use modules derivatives to compute the nth-derivative of most of the
+nt2 functors, and module automatic_derivative to compute first order derivatives of your own
+nt2-written functions with floating point accuracy.
+
+
+[endsect]
+
+[xinclude reference.xml]

--- a/modules/core/numerical_derivatives/doc/reference.doxyfile
+++ b/modules/core/numerical_derivatives/doc/reference.doxyfile
@@ -1,0 +1,23 @@
+################################################################################
+#         Copyright 2003 - 2012  LASMEA UMR 6602 CNRS/Univ. Clermont II
+#         Copyright 2009 - 2012  LRI    UMR 8623 CNRS/Univ Paris Sud XI
+#
+#          Distributed under the Boost Software License, Version 1.0.
+#                 See accompanying file LICENSE.txt or copy at
+#                     http://www.boost.org/LICENSE_1_0.txt
+################################################################################
+WARN_IF_UNDOCUMENTED   = YES
+WARNINGS               = YES
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+HIDE_UNDOC_MEMBERS     = YES
+HIDE_UNDOC_CLASSES     = YES
+HIDE_SCOPE_NAMES       = YES
+INLINE_INFO            = YES
+INTERNAL_DOCS          = NO
+INPUT                  = ../include/nt2/numerical_derivatives/functions
+INPUT                 += ../include/nt2/numerical_derivatives/constants
+FULL_PATH_NAMES        = NO
+INHERIT_DOCS           = NO
+RECURSIVE              = NO
+EXTRA_PACKAGES         = amssymb

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivinc.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivinc.hpp
@@ -1,0 +1,68 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINC_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINC_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <boost/simd/constant/register.hpp>
+#include <boost/simd/constant/hierarchy.hpp>
+
+
+namespace nt2
+{
+  namespace tag
+  {
+   /*!
+     @brief Derivinc generic tag
+
+     Represents the Derivinc constant in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    BOOST_SIMD_CONSTANT_REGISTER( Derivinc, double, 1
+                                , 0x39800000, 0x3e5000000000000dll
+                                )
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::Derivinc, Site>
+   dispatching_Derivinc(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::Derivinc, Site>();
+   }
+   template<class... Args>
+   struct impl_Derivinc;
+  }
+  /*!
+    Generate an increment for finite difference for derivative approximation
+
+    @par Semantic:
+
+    @code
+    T r = Derivinc<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    if T is integral
+      r = 1
+    else if T is double
+      r =  Pow(2,-26);
+    else if T is float
+      r =  pow(2,-12);
+    @endcode
+  **/
+  BOOST_SIMD_CONSTANT_IMPLEMENTATION(nt2::tag::Derivinc, Derivinc)
+}
+
+#include <boost/simd/constant/common.hpp>
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivinc2.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivinc2.hpp
@@ -1,0 +1,69 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINC2_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINC2_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <boost/simd/constant/register.hpp>
+#include <boost/simd/constant/hierarchy.hpp>
+
+
+namespace nt2
+{
+  namespace tag
+  {
+   /*!
+     @brief Derivinc2 generic tag
+
+     Represents the Derivinc2 constant in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    BOOST_SIMD_CONSTANT_REGISTER( Derivinc2, double, 1
+                                , 0x3d000000, 0x3f30000000000000ll
+                                )
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::Derivinc2, Site>
+   dispatching_Derivinc2(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::Derivinc2, Site>();
+   }
+   template<class... Args>
+   struct impl_Derivinc2;
+  }
+  /*!
+    Generate an increment for finite difference for second
+    derivative approximation
+
+    @par Semantic:
+
+    @code
+    T r = Derivinc2<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    if T is integral
+      r = 1
+    else if T is double
+      r =  Pow(2,-12);
+    else if T is float
+      r =  pow(2,-5);
+    @endcode
+  **/
+  BOOST_SIMD_CONSTANT_IMPLEMENTATION(nt2::tag::Derivinc2, Derivinc2)
+}
+
+#include <boost/simd/constant/common.hpp>
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivincc.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivincc.hpp
@@ -1,0 +1,68 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINCC_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINCC_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <boost/simd/constant/register.hpp>
+#include <boost/simd/constant/hierarchy.hpp>
+
+
+namespace nt2
+{
+  namespace tag
+  {
+   /*!
+     @brief Derivincc generic tag
+
+     Represents the Derivincc constant in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    BOOST_SIMD_CONSTANT_REGISTER( Derivincc, double, 1
+                                , 0x39000000, 0x3dc0000000000000ll
+                                )
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::Derivincc, Site>
+   dispatching_Derivincc(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::Derivincc, Site>();
+   }
+   template<class... Args>
+   struct impl_Derivincc;
+  }
+  /*!
+    Generate an increment for centered finite difference for derivative approximation
+
+    @par Semantic:
+
+    @code
+    T r = Derivincc<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    if T is integral
+      r = 1
+    else if T is double
+      r =  Pow(2,-35);
+    else if T is float
+      r =  pow(2,-14);
+    @endcode
+  **/
+  BOOST_SIMD_CONSTANT_IMPLEMENTATION(nt2::tag::Derivincc, Derivincc)
+}
+
+#include <boost/simd/constant/common.hpp>
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivincgm.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/derivincgm.hpp
@@ -1,0 +1,69 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINCGM_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_CONSTANTS_DERIVINCGM_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <boost/simd/constant/register.hpp>
+#include <boost/simd/constant/hierarchy.hpp>
+
+
+namespace nt2
+{
+  namespace tag
+  {
+   /*!
+     @brief Derivincgm generic tag
+
+     Represents the Derivincgm constant in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    BOOST_SIMD_CONSTANT_REGISTER( Derivincgm, double, 1
+                                , 0x3b000000, 0x3ed0000000000000ll
+                                )
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::Derivincgm, Site>
+   dispatching_Derivincgm(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::Derivincgm, Site>();
+   }
+   template<class... Args>
+   struct impl_Derivincgm;
+  }
+  /*!
+    Generate an increment for finite difference for second
+    derivative approximation
+
+    @par Semantic:
+
+    @code
+    T r = Derivincgm<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    if T is integral
+      r = 1
+    else if T is double
+      r =  Pow(2,-18);
+    else if T is float
+      r =  pow(2,-9);
+    @endcode
+  **/
+  BOOST_SIMD_CONSTANT_IMPLEMENTATION(nt2::tag::Derivincgm, Derivincgm)
+}
+
+#include <boost/simd/constant/common.hpp>
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/inveps.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/inveps.hpp
@@ -1,0 +1,68 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_CONSTANTS_INVEPS_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_CONSTANTS_INVEPS_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <boost/simd/constant/register.hpp>
+#include <boost/simd/constant/hierarchy.hpp>
+
+
+namespace nt2
+{
+  namespace tag
+  {
+   /*!
+     @brief Inveps generic tag
+
+     Represents the Inveps constant in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    BOOST_SIMD_CONSTANT_REGISTER( Inveps, double, 1
+                                , 0x4b000000, 0x4330000000000000ll
+                                )
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::Inveps, Site>
+   dispatching_Inveps(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::Inveps, Site>();
+   }
+   template<class... Args>
+   struct impl_Inveps;
+  }
+  /*!
+    inverse of machine precision to avoid dividing by eps
+
+    @par Semantic:
+
+    @code
+    T r = Inveps<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    if T is integral
+      r = 1
+    else if T is double
+      r =  Pow(2,52);
+    else if T is float
+      r =  pow(2,23);
+    @endcode
+  **/
+  BOOST_SIMD_CONSTANT_IMPLEMENTATION(nt2::tag::Inveps, Inveps)
+}
+
+#include <boost/simd/constant/common.hpp>
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/inveps2.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/constants/inveps2.hpp
@@ -1,0 +1,68 @@
+//==============================================================================
+//          Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_CONSTANTS_INVEPS2_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_CONSTANTS_INVEPS2_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <boost/simd/constant/register.hpp>
+#include <boost/simd/constant/hierarchy.hpp>
+
+
+namespace nt2
+{
+  namespace tag
+  {
+   /*!
+     @brief Inveps2 generic tag
+
+     Represents the Inveps2 constant in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    BOOST_SIMD_CONSTANT_REGISTER( Inveps2, double, 1
+                                , 0x56800000, 0x4670000000000007ll
+                                )
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::Inveps2, Site>
+   dispatching_Inveps2(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::Inveps2, Site>();
+   }
+   template<class... Args>
+   struct impl_Inveps2;
+  }
+  /*!
+    inverse of machine precision to avoid dividing by eps
+
+    @par Semantic:
+
+    @code
+    T r = Inveps2<T>();
+    @endcode
+
+    is similar to:
+
+    @code
+    if T is integral
+      r = 1
+    else if T is double
+      r =  Pow(2,104);
+    else if T is float
+      r =  pow(2,56);
+    @endcode
+  **/
+  BOOST_SIMD_CONSTANT_IMPLEMENTATION(nt2::tag::Inveps2, Inveps2)
+}
+
+#include <boost/simd/constant/common.hpp>
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/details/choosediags.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/details/choosediags.hpp
@@ -1,0 +1,76 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_MODULES_CORE_NUMERICAL_DERIVATIVES_UNIT_DETAILS_CHOOSEDIAGS_HPP_INCLUDED
+#define NT2_MODULES_CORE_NUMERICAL_DERIVATIVES_UNIT_DETAILS_CHOOSEDIAGS_HPP_INCLUDED
+#include <nt2/include/functions/is_equal.hpp>
+#include <nt2/sdk/meta/strip.hpp>
+#include <nt2/sdk/meta/as_logical.hpp>
+
+namespace nt2 { namespace details
+{
+  struct choosediags
+  {
+    template<class Sig> struct result;
+
+    template<class This, class A0, class A1, class A2>
+    struct result<This(A0,A1,A2)>
+    {
+      typedef typename nt2::meta::strip<A0>::type a0_t;
+      typedef typename nt2::meta::as_logical<a0_t>::type type;
+    };
+
+    template < class A0, class A1, class A2>
+    typename nt2::meta::as_logical<A0>::type
+    operator()(const A0&i, const A1&j, const A2& ) const
+    {
+      return nt2::eq(i, j);
+    }
+  };
+ struct choosediag
+  {
+    template<class Sig> struct result;
+
+    template<class This, class A0, class A1>
+    struct result<This(A0,A1)>
+    {
+      typedef typename nt2::meta::strip<A0>::type a0_t;
+      typedef typename nt2::meta::as_logical<a0_t>::type type;
+    };
+
+    template < class A0, class A1>
+    typename nt2::meta::as_logical<A0>::type
+    operator()(const A0&i, const A1&j) const
+    {
+      return nt2::eq(i, j);
+    }
+  };
+   struct chooserows
+  {
+    template<class Sig> struct result;
+
+    template<class This, class A0, class A1, class A2>
+    struct result<This(A0,A1,A2)>
+    {
+      typedef typename nt2::meta::strip<A0>::type a0_t;
+      typedef typename nt2::meta::as_logical<a0_t>::type type;
+    };
+
+    template < class A0, class A1, class A2>
+    typename nt2::meta::as_logical<A0>::type
+    operator()(const A0&i, const A1&, const A2&k ) const
+    {
+      return nt2::eq(i, k);
+    }
+  };
+
+
+} }
+
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/details/compute_h.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/details/compute_h.hpp
@@ -1,0 +1,64 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_MODULES_CORE_NUMERICAL_DERIVATIVES_UNIT_DETAILS_COMPUTE_H_HPP_INCLUDED
+#define NT2_MODULES_CORE_NUMERICAL_DERIVATIVES_UNIT_DETAILS_COMPUTE_H_HPP_INCLUDED
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/exponent.hpp>
+#include <nt2/include/functions/fast_ldexp.hpp>
+#include <nt2/include/functions/max.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <boost/mpl/int.hpp>
+
+namespace nt2 { namespace details
+{
+  template < class R>
+  struct compute
+  {
+    template < class X, class C>
+    static BOOST_FORCEINLINE auto h(const X & x, R epsi
+                                   , const boost::mpl::long_<2> &
+                                   , const C&)
+      -> decltype(max(epsi*abs(x), epsi))
+    {
+      return max(epsi*nt2::abs(x), epsi);
+    }
+    template < class X >
+    static BOOST_FORCEINLINE auto h(const X & x, R epsi
+                                   , const boost::mpl::long_<3> &
+                                   ,  const boost::mpl::true_&)
+      -> decltype(max(epsi*abs(x), epsi))
+    {
+      return max(epsi*nt2::abs(x), epsi);
+    }
+    template < class X >
+    static BOOST_FORCEINLINE auto h(const X & x, R epsi
+                                   , const boost::mpl::long_<3> &
+                                   ,  const boost::mpl::false_&)
+      ->  decltype(max(epsi*fast_ldexp(One<R>(), exponent(x)), epsi))
+    {
+      R e = fast_ldexp(One<R>(), exponent(epsi));
+      return max(e*fast_ldexp(One<R>(), exponent(x)), e);
+    }
+
+    template < class X, class C>
+    static BOOST_FORCEINLINE auto h(const X & x, R epsi
+                                    , const boost::mpl::long_<4> &
+                                    , const C&)
+      -> decltype(max(epsi*fast_ldexp(One<R>(), exponent(x)), epsi))
+    {
+      R e = fast_ldexp(One<R>(), exponent(epsi));
+      return max(e*fast_ldexp(One<R>(), exponent(x)), e);
+    }
+  };
+
+} }
+
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/details/get_epsi.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/details/get_epsi.hpp
@@ -1,0 +1,54 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_MODULES_CORE_NUMERICAL_DERIVATIVES_UNIT_DETAILS_GET_EPSI_HPP_INCLUDED
+#define NT2_MODULES_CORE_NUMERICAL_DERIVATIVES_UNIT_DETAILS_GET_EPSI_HPP_INCLUDED
+#include <boost/mpl/int.hpp>
+#include <nt2/sdk/meta/is_scalar.hpp>
+#include <boost/dispatch/dsl/semantic_of.hpp>
+
+namespace nt2 { namespace details
+{
+  // if epsi is not a scalar a fallback is provided
+  template <class A1, class R>
+  struct get
+  {
+    static BOOST_FORCEINLINE R epsi(const A1&, const R & fallback
+                                   , const boost::mpl::long_<2> & )
+    {
+      return fallback;
+    }
+    static BOOST_FORCEINLINE R epsi(const A1& in, const R & fallback
+                                   , const boost::mpl::long_<3> & )
+    {
+      typedef typename boost::proto::result_of::child_c<A1&, 2>::value_type child2_t;
+      typedef typename boost::dispatch::meta::semantic_of<child2_t>::type semantic_t;
+      typedef typename meta::is_scalar<semantic_t>::type                    choose_t;
+      return epsi(in, fallback, choose_t(), boost::mpl::long_<3>());
+    }
+    static BOOST_FORCEINLINE R epsi(const A1&, const R & fallback
+                                   , boost::mpl::false_, const boost::mpl::long_<3> & )
+    {
+      return  fallback;
+    }
+    static BOOST_FORCEINLINE R epsi(const A1& in, const R &
+                                   , boost::mpl::true_, const boost::mpl::long_<3> & )
+    {
+      return   boost::proto::value(boost::proto::child_c<2>(in));
+    }
+    static BOOST_FORCEINLINE R epsi(const A1& in, const R &
+                                   , const boost::mpl::long_<4> & )
+    {
+      return  boost::proto::value(boost::proto::child_c<2>(in));
+    }
+  };
+
+} }
+
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/backward.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/backward.hpp
@@ -1,0 +1,104 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_BACKWARD_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_BACKWARD_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief backward generic tag
+
+     Represents the backward function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct backward_ : ext::unspecified_<backward_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<backward_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_backward_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::backward_, Site>
+   dispatching_backward_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::backward_, Site>();
+   }
+   template<class... Args>
+   struct impl_backward_;
+  }
+  /*!
+    Computes the divided backward difference to evaluate a derivative.
+
+
+    @par Semantic:
+
+    For every functor f and x of floating type T
+
+    @code
+    dfdx = backward(f, x{, epsi}{,  pow2den_});
+    @endcode
+
+    is equivalent to
+
+    @code
+    dfdx = (f(x)-f(x-h))/h);
+    @endcode
+
+    h computed value is max(epsi*abs(x), epsi) except if pow2den_ option is used
+    in which case it is given by h = max(e*ldexp(1, (exponent(x)), e)
+    where  e = ldexp(T(1), exponent(epsi)) that insures the denominator of the quotient
+    is a power of 2 and can help gain some more correct digits on the result.
+
+    @see @funcref{forward}, @funcref{centered}, @funcref{vand}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+    @param epsi default to Derivinc<T>())
+    @param pow2den_  try enhancing precision by computing a h value that is a power of 2.
+
+    @return the derivative value
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::backward_, backward, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::backward_, backward, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::backward_, backward, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::backward_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/centered.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/centered.hpp
@@ -1,0 +1,105 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_CENTERED_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_CENTERED_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief centered generic tag
+
+     Represents the centered function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct centered_ : ext::unspecified_<centered_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<centered_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_centered_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::centered_, Site>
+   dispatching_centered_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::centered_, Site>();
+   }
+   template<class... Args>
+   struct impl_centered_;
+  }
+  /*!
+    Computes the divided centered difference to evaluate a derivative.
+
+
+    @par Semantic:
+
+    For every functor f and matrix expresion x of floating type T elements
+
+    @code
+    dfdx = centered(f, x{, epsi}{,  pow2den_});
+    @endcode
+
+    is equivalent to
+
+    @code
+    dfdx = (f(x+h)-f(x-h))/(2*h));
+    @endcode
+
+    h computed value is max(epsi*abs(x), epsi) except if pow2den_ option is used
+    in which case it is given by h = max(e*ldexp(1, (exponent(x)), e)
+    where  e = ldexp(T(1), exponent(epsi)) that insures that the denominator of the quotient
+    is a power of 2 and can help gain some more correct digits on the result.
+
+    @see @funcref{forward}, @funcref{centered}, @funcref{vand}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+    @param epsi default to Derivinc<T>())
+    @param pow2den_  try enhancing precision by computing a h value that is a power of 2.
+
+    @return the derivative value
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::centered_, centered, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::centered_, centered, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::centered_, centered, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::centered_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/d2f.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/d2f.hpp
@@ -1,0 +1,106 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_D2F_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_D2F_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief d2f generic tag
+
+     Represents the d2f function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct d2f_ : ext::unspecified_<d2f_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<d2f_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_d2f_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::d2f_, Site>
+   dispatching_d2f_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::d2f_, Site>();
+   }
+   template<class... Args>
+   struct impl_d2f_;
+  }
+  /*!
+    Computes the divided d2f difference to evaluate a second order derivative.
+    If f is from \f$K^n\f to K this is the hessian diagonal.
+
+
+    @par Semantic:
+
+    For every functor f and matrix expresion x of floating type T elements
+
+    @code
+    dfdx = d2f(f, x{, epsi}{,  pow2den_});
+    @endcode
+
+    is equivalent to
+
+    @code
+    dfdx = (f(x+h)-2*f(x)+f(x-h))/(h*h));
+    @endcode
+
+    h computed value is max(epsi*abs(x), epsi) except if pow2den_ option is used
+    in which case it is given by h = max(e*ldexp(1, (exponent(x)), e)
+    where  e = ldexp(T(1), exponent(epsi)) that insures that the denominator of the quotient
+    is a power of 2 and can help gain some more correct digits on the result.
+
+    @see @funcref{forward}, @funcref{d2f}, @funcref{vand}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+    @param epsi default to Derivinc2<T>())
+    @param pow2den_  try enhancing precision by computing a h value that is a power of 2.
+
+    @return the derivative value
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::d2f_, d2f, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::d2f_, d2f, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::d2f_, d2f, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::d2f_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/df.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/df.hpp
@@ -1,0 +1,110 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_DF_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_DF_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief df generic tag
+
+     Represents the df function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct df_ : ext::unspecified_<df_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<df_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_df_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::df_, Site>
+   dispatching_df_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::df_, Site>();
+   }
+   template<class... Args>
+   struct impl_df_;
+  }
+  /*!
+    Computes the numerical approximation first order derivatives of a function f
+    from \f$R^n$\f to \f$K^m$\f (where \f$K\f$ is \f$R\f$ or \f$C\f$),  using
+     forward,  backward,  centered or vand (very acurate numerical derivative method).
+
+    vand is reserved to real functions (\f$K\f$ is \f$R\f$) that can be nonetheless evaluated
+    for complex inputs (this method is insensitive to epsi and pow2den_ parameters) ;
+
+    @par Semantic:
+
+    For every functor f and matrix expresion x of floating type T elements
+
+    @code
+    dfdx = df(f, x,  method{, epsi}{,  pow2den_});
+    @endcode
+
+    is respectively equivalent to
+
+    @code
+    dfdx = (f(x+h)-f(x-h))/(2*h); if method is nt2::tag::centered_
+    dfdx = (f(x+h)-f(x))/h;       if method is nt2::tag::forward_
+    dfdx = (f(x)-f(x-h))/h;       if method is nt2::tag::backward_
+    dfdx = imag(f(x)/Eps<T>());   if method is nt2::tag::vand_
+    @endcode
+
+    h is computed automatically using the inputs and Derivinc constant.
+    If you want more control on epsi use one of @funcref{forward}, @funcref{backward},
+    @funcref{centered} functors or/and the pow2den_ parameter.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}, @funcref{vand}, @funcref{Derivinc}, @funcref{gradient}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+    @param method used in numerical numerical_derivatives
+    @param pow2den_  try enhancing precision by computing a h value that is a power of 2.
+
+    @return the derivative value
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::df_, df, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::df_, df, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::df_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/backward.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/backward.hpp
@@ -1,0 +1,74 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_BACKWARD_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_BACKWARD_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/backward.hpp>
+#include <nt2/include/functions/depth.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/reshape.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/whereijk.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/numerical_derivatives/details/choosediags.hpp>
+#include <nt2/numerical_derivatives/details/compute_h.hpp>
+#include <nt2/numerical_derivatives/details/get_epsi.hpp>
+#include <nt2/core/container/colon/colon.hpp>
+
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::backward_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+    typedef typename A0::value_type                    type_t;
+    typedef typename meta::as_real<type_t>::type      rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, N::value-1>::value_type vtype_t;
+    typedef typename meta::is_scalar<vtype_t>::type                   semantic_t;
+    typedef typename meta::is_scalar< semantic_t>::type                 choice_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x0); // number of coefficients in an input vector
+      std::size_t nbvec = width(x0);    // number of f input vectors
+      auto x =  reshape(x0, nbcoefs, 1, nbvec);
+      rtype_t epsi =  details::get<A1, rtype_t>::epsi(in, Derivinc<rtype_t>(), N());
+      auto h = details::compute<rtype_t>::h(x, epsi, N(), choice_t());
+      auto hh = expand_to(h, nbcoefs, nbcoefs,  nbvec);
+      auto dx = whereijk(details::choosediags(), hh, Zero<rtype_t>());
+      auto xx =  sx(nt2::tag::minus_(),x, dx);
+      out = sx(nt2::tag::divides_()
+                 , sx(nt2::tag::minus_()
+                     , reshape(f(x), _(), 1, nbvec)
+                     , reshape(f(xx), _(), nbcoefs, nbvec)
+                     )
+                 , reshape(h, 1, height(h), depth(h)));
+       return out;
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/centered.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/centered.hpp
@@ -1,0 +1,75 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_CENTERED_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_CENTERED_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/centered.hpp>
+#include <nt2/include/functions/depth.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/reshape.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/whereijk.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/derivincc.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/numerical_derivatives/details/choosediags.hpp>
+#include <nt2/numerical_derivatives/details/compute_h.hpp>
+#include <nt2/numerical_derivatives/details/get_epsi.hpp>
+#include <nt2/core/container/colon/colon.hpp>
+
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::centered_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+    typedef typename A0::value_type                    type_t;
+    typedef typename meta::as_real<type_t>::type      rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, N::value-1>::value_type vtype_t;
+    typedef typename meta::is_scalar<vtype_t>::type                   semantic_t;
+    typedef typename meta::is_scalar< semantic_t>::type                 choice_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x0); // number of coefficients in an input vector
+      std::size_t nbvec = width(x0);    // number of f input vectors
+      auto x =  reshape(x0, nbcoefs, 1, nbvec);
+      rtype_t epsi =  details::get<A1, rtype_t>::epsi(in, Derivincc<rtype_t>(), N());
+      auto h = details::compute<rtype_t>::h(x, epsi, N(), choice_t());
+      auto hh = expand_to(h, nbcoefs, nbcoefs,  nbvec);
+      auto dx = whereijk(details::choosediags(), hh, Zero<rtype_t>());
+      auto xxp =  sx(nt2::tag::plus_(),x, dx);
+      auto xxm =  sx(nt2::tag::minus_(),x, dx);
+      out = sx(nt2::tag::divides_()
+                 , sx(nt2::tag::minus_()
+                     , reshape(f(xxp), _(), nbcoefs, nbvec)
+                     , reshape(f(xxm), _(), nbcoefs, nbvec)
+                     )
+                 , reshape(h+h, 1, height(h), depth(h)));
+      return out;
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/d2f.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/d2f.hpp
@@ -1,0 +1,81 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_D2F_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_D2F_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/d2f.hpp>
+#include <nt2/include/functions/depth.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/fma.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/reshape.hpp>
+#include <nt2/include/functions/sqr.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/whereijk.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/include/constants/mtwo.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/numerical_derivatives/details/choosediags.hpp>
+#include <nt2/numerical_derivatives/details/compute_h.hpp>
+#include <nt2/numerical_derivatives/details/get_epsi.hpp>
+#include <nt2/core/container/colon/colon.hpp>
+
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::d2f_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+    typedef typename A0::value_type                    type_t;
+    typedef typename meta::as_real<type_t>::type      rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, N::value-1>::value_type vtype_t;
+    typedef typename meta::is_scalar< vtype_t>::type choice_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x0); // number of coefficients in an input vector
+      std::size_t nbvec = width(x0);    // number of f input vectors
+      auto x =  reshape(x0, nbcoefs, 1, nbvec);
+      rtype_t epsi =  details::get<A1, rtype_t>::epsi(in, Derivinc2<rtype_t>(), N());
+      auto h = details::compute<rtype_t>::h(x, epsi, N(), choice_t());
+      auto hh = expand_to(h, nbcoefs, nbcoefs,  nbvec);
+      auto dx = whereijk(details::choosediags(), hh, Zero<rtype_t>());
+      auto xxp =  sx(nt2::tag::plus_(),x, dx);
+      auto xxm =  sx(nt2::tag::minus_(),x, dx);
+      out = sx(nt2::tag::divides_()
+                 , sx(nt2::tag::fma_()
+                     , reshape(f(x),  _(), 1, nbvec)
+                     , Mtwo<rtype_t>()
+                     , sx(nt2::tag::plus_()
+                         , reshape(f(xxp), _(), nbcoefs, nbvec)
+                         , reshape(f(xxm), _(), nbcoefs, nbvec)
+                         )
+                     )
+              , reshape(sqr(h), 1, height(h), depth(h)));
+      return out;
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/df.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/df.hpp
@@ -1,0 +1,60 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_DF_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_DF_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/df.hpp>
+#include <nt2/include/functions/backward.hpp>
+#include <nt2/include/functions/centered.hpp>
+#include <nt2/include/functions/forward.hpp>
+#include <nt2/include/functions/vand.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/table.hpp>
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::df_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+    typedef typename A0::value_type                    type_t;
+    typedef typename meta::as_real<type_t>::type      rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, 2>::value_type tag_t;
+    typedef typename tag_t::value_type::option_type  method_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      compute(out, f, x0, N());
+      return out;
+    }
+  private :
+    template < class A, class F, class X>
+    static void compute(A& out, const F & f,  const X& x, const boost::mpl::long_<3> &)
+    {
+      out = functor<method_t>()(f, x);
+    }
+    template <class A, class F, class X>
+    static void compute(A& out, const F & f,  const  X& x, const boost::mpl::long_<4> &)
+    {
+      typedef typename boost::proto::result_of::child_c<A1&, 3>::value_type opt_t;
+      out = functor<method_t>()(f, x, opt_t());
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/forward.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/forward.hpp
@@ -1,0 +1,74 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_FORWARD_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_FORWARD_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/forward.hpp>
+#include <nt2/include/functions/depth.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/reshape.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/whereijk.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/numerical_derivatives/details/choosediags.hpp>
+#include <nt2/numerical_derivatives/details/compute_h.hpp>
+#include <nt2/numerical_derivatives/details/get_epsi.hpp>
+#include <nt2/core/container/colon/colon.hpp>
+
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::forward_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+    typedef typename A0::value_type                    type_t;
+    typedef typename meta::as_real<type_t>::type      rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, N::value-1>::value_type vtype_t;
+    typedef typename meta::is_scalar<vtype_t>::type                   semantic_t;
+    typedef typename meta::is_scalar< semantic_t>::type                 choice_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x0); // number of coefficients in an input vector
+      std::size_t nbvec = width(x0);    // number of f input vectors
+      auto x =  reshape(x0, nbcoefs, 1, nbvec);
+      rtype_t epsi =  details::get<A1, rtype_t>::epsi(in, Derivinc<rtype_t>(), N());
+      auto h = details::compute<rtype_t>::h(x, epsi, N(), choice_t());
+      auto hh = expand_to(h, nbcoefs, nbcoefs,  nbvec);
+      auto dx = whereijk(details::choosediags(), hh, Zero<rtype_t>());
+      auto xx =  sx(nt2::tag::plus_(),x, dx);
+      out = sx(nt2::tag::divides_()
+                 , sx(nt2::tag::minus_()
+                     , reshape(f(xx), _(), nbcoefs, nbvec)
+                     , reshape(f(x), _(), 1, nbvec)
+                     )
+              , reshape(h, 1, height(h), depth(h)));
+      return out;
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/gillmurray.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/gillmurray.hpp
@@ -1,0 +1,89 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_GILLMURRAY_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_GILLMURRAY_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/gillmurray.hpp>
+#include <nt2/include/functions/depth.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/repmat.hpp>
+#include <nt2/include/functions/rowvect.hpp>
+#include <nt2/include/functions/reshape.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/whereij.hpp>
+#include <nt2/include/functions/whereijk.hpp>
+#include <nt2/include/constants/zero.hpp>
+#include <nt2/include/constants/derivincgm.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/numerical_derivatives/details/choosediags.hpp>
+#include <nt2/numerical_derivatives/details/compute_h.hpp>
+#include <nt2/numerical_derivatives/details/get_epsi.hpp>
+#include <nt2/core/container/colon/colon.hpp>
+
+#include <nt2/table.hpp>
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::gillmurray_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                                      result_type;
+    typedef typename A0::value_type                                       type_t;
+    typedef typename meta::as_real<type_t>::type                         rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, N::value-1>::value_type vtype_t;
+    typedef typename meta::is_scalar<vtype_t>::type                   semantic_t;
+    typedef typename meta::is_scalar< semantic_t>::type                 choice_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x0); // number of coefficients in an input vector
+      std::size_t nbvec = width(x0);    // number of f input vectors
+      out.resize(of_size(nbcoefs, nbcoefs, nbvec));
+      for(std::size_t k = 1; k <= nbvec;  ++k)
+      {
+        auto x0k = x0(_, k);
+        auto x  =  expand_to(x0k, nbcoefs, nbcoefs, nbcoefs);
+        rtype_t epsi =  details::get<A1, rtype_t>::epsi(in, Derivincgm<rtype_t>(), N());
+        auto h0 = details::compute<rtype_t>::h(x0k, epsi, N(), choice_t());
+        auto hh = expand_to(h0, nbcoefs, nbcoefs);
+        auto hhh = expand_to(h0, nbcoefs, nbcoefs, nbcoefs);
+        auto dx = whereij(details::choosediag(), hh, Zero<rtype_t>());
+        auto dx0 = whereijk(details::chooserows(), hhh, Zero<rtype_t>());
+        auto dx1 = repmat(dx, 1, 1, nbcoefs);
+        auto xxi  =  sx(nt2::tag::plus_(), x, dx0);
+        auto xxj  =  sx(nt2::tag::plus_(), x, dx1);
+        auto xxij =  sx(nt2::tag::plus_(), xxi, dx);
+        //why auto cannot be put there ?
+        table<type_t> fh1h2  = reshape(f(xxij), nbcoefs, nbcoefs);
+        table<type_t> fh1    = reshape(f(xxi), nbcoefs, nbcoefs);
+        table<type_t> fh2    = reshape(f(xxj), nbcoefs, nbcoefs);
+        type_t fx    = f(x0k);
+        auto hihj =  sx(tag::multiplies_(), h0, rowvect(h0));
+        out(_, _, k)= sx(nt2::tag::divides_(), (sx(nt2::tag::plus_(), fh1h2-fh1-fh2, fx)), hihj);
+      }
+
+      return out;
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/gradient.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/gradient.hpp
@@ -1,0 +1,62 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_GRADIENT_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_GRADIENT_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/gradient.hpp>
+#include <nt2/include/functions/backward.hpp>
+#include <nt2/include/functions/centered.hpp>
+#include <nt2/include/functions/forward.hpp>
+#include <nt2/include/functions/vand.hpp>
+#include <nt2/include/functions/squeeze.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::gradient_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x0 = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      auto method = boost::proto::value(boost::proto::child_c<2>(in));
+      compute(out, f, x0, method, N());
+      out = reshape(out, of_size(size(out, 2), size(out, 3)));
+      return out;
+    }
+  private :
+    template < class F, class X,  class M>
+    static void compute(A0& out, const F & f,  const X& x,  const M & , const boost::mpl::long_<3> &)
+    {
+      out = functor<M>()(f, x);
+    }
+    template < class F, class X,  class M>
+    static void compute(A0& out, const F & f,  const  X& x,  const M & , const boost::mpl::long_<4> &)
+    {
+      out = functor<M>()(f, x, nt2::pow2den_);
+    }
+    template < class F, class X>
+    static void compute(A0& out, const F & f,  const X& x,  const tag::vand_ &, const boost::mpl::long_<4> &)
+    {
+      out = vand(f, x);
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/vand.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/vand.hpp
@@ -1,0 +1,57 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_VAND_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_VAND_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/vand.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/imag.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/functions/eye.hpp>
+#include <nt2/include/constants/eps.hpp>
+#include <nt2/include/constants/inveps.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::vand_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                 result_type;
+    typedef typename A0::value_type                  type_t;
+    typedef typename meta::as_complex<type_t>::type ctype_t;
+    typedef typename meta::as_real<type_t>::type    rtype_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x); // number of coefficients in an input f vector
+      std::size_t nbvec = width(x);    // number of f input vectors
+      auto x1 = reshape(x, nbcoefs, 1, nbvec);
+      auto e = nt2::Eps<rtype_t>()*nt2::eye(nbcoefs, nbcoefs, 1, nt2::meta::as_<rtype_t>());
+      auto xc =  sx(nt2::tag::tocomplex_(),x1, e);
+      out = reshape(imag(f(xc)*Inveps<rtype_t>()), _(), nbcoefs, nbvec);
+      return out;
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/vand2.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/expr/vand2.hpp
@@ -1,0 +1,61 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_VAND2_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_EXPR_VAND2_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/vand2.hpp>
+#include <nt2/numerical_derivatives/functions/vand.hpp>
+#include <nt2/include/functions/sx.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/height.hpp>
+#include <nt2/include/functions/width.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/imag.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/functions/eye.hpp>
+#include <nt2/include/constants/eps.hpp>
+#include <nt2/include/constants/inveps2.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/table.hpp>
+
+namespace nt2 { namespace ext
+{
+ BOOST_DISPATCH_IMPLEMENT  ( run_assign_, tag::cpu_
+                            , (A0)(A1)(N)
+                            , ((ast_<A0, nt2::container::domain>))
+                              ((node_ < A1, nt2::tag::vand2_, N
+                                      , nt2::container::domain
+                                      >
+                              ))
+                            )
+  {
+    typedef A0&                                   result_type;
+    typedef typename A0::value_type                    type_t;
+    typedef typename meta::as_real<type_t>::type      rtype_t;
+    typedef typename boost::proto::result_of::child_c<A1&, N::value-1>::value_type vtype_t;
+    typedef typename meta::is_scalar< vtype_t>::type choice_t;
+
+    result_type operator()(A0& out, const A1& in ) const
+    {
+      auto x = boost::proto::child_c<1>(in);
+      auto f =  boost::proto::value(boost::proto::child_c<0>(in));
+      std::size_t nbcoefs = height(x); // number of coefficients in an input f vector
+      std::size_t nbvec = width(x);    // number of f input vectors
+      auto x1 = reshape(x, nbcoefs, 1, nbvec);
+      auto e   = nt2::Eps<rtype_t>()*nt2::eye(nbcoefs, nbcoefs, 1, nt2::meta::as_<rtype_t>());
+      auto xc =  sx(nt2::tag::tocomplex_(),x1, e);
+      out = reshape((Two<rtype_t>()*real(f(x))-real(f(xc)))*Inveps2<rtype_t>(), _(), nbcoefs, nbvec);
+      return out;
+    }
+  };
+
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/forward.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/forward.hpp
@@ -1,0 +1,106 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_FORWARD_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_FORWARD_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief forward generic tag
+
+     Represents the forward function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct forward_ : ext::unspecified_<forward_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<forward_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_forward_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::forward_, Site>
+   dispatching_forward_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::forward_, Site>();
+   }
+   template<class... Args>
+   struct impl_forward_;
+  }
+  /*!
+    Computes the divided forward difference to evaluate a derivative.
+
+
+    @par Semantic:
+
+    For every functor f and x of floating type T
+
+    @code
+    dfdx = forward(f, x{, epsi}{,  pow2den_});
+    @endcode
+
+    is equivalent to
+
+    @code
+    dfdx = (f(x+h)-f(x))/h);
+    @endcode
+
+    h computed value is max(epsi*abs(x), epsi) except if pow2den_ option is used
+    in which case it is given by h = max(e*ldexp(1, (exponent(x)), e)
+    where  e = ldexp(T(1), exponent(epsi)) that insures that the denominator of the quotient
+    is a power of 2 and can help gain some more correct digits on the result.
+
+
+    @see @funcref{backward}, @funcref{centered}, @funcref{vand}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+    @param epsi default to Derivinc<T>())
+    @param pow2den_ try enhancing precision by computing a h value that is a power of 2.
+
+    @return the derivative value
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::forward_, forward, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::forward_, forward, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::forward_, forward, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::forward_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/gillmurray.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/gillmurray.hpp
@@ -1,0 +1,117 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_GILLMURRAY_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_GILLMURRAY_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief gillmurray generic tag
+
+     Represents the gillmurray function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct gillmurray_ : ext::unspecified_<gillmurray_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<gillmurray_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_gillmurray_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::gillmurray_, Site>
+   dispatching_gillmurray_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::gillmurray_, Site>();
+   }
+   template<class... Args>
+   struct impl_gillmurray_;
+  }
+  /*!
+    Computes  (second order derivative) numerical derivative the using the  Gill-Murray formula.
+
+    @par Semantic:
+
+    For every functor f from \f$R^n$\f (height(x)) to \f$R$\f and  matrix expression x of size nxp
+    of floating elements of type T will produce a matrix expression of size mxnxn (
+    the kth result page is the hessian of f computed at the kth column of the entry
+
+    It computes only the onal of the gillmurray matrix at each point as
+    columns vectors of a matrix result.
+
+    @code
+    dfdx = gillmurray(f, x{, epsi}{,  pow2den_});
+    @endcode
+
+    is equivalent to
+
+    @code
+    for (k = 1, k <= p, ++k)
+    {
+      for (i = 1, i <= n, ++i)
+      {
+        for (j = 1, j <= n, ++j)
+        {
+          d2fdx2(_, i, j) = (f(x+hi*ei+hj*ej)-f(x+hi*ei)-f(x+hj*ej)+f(x))/(hi*hj)
+        }
+      }
+    }
+    @endcode
+
+    the hi values computed values are max(epsi*abs(xi), epsi) except if pow2den_ option is used
+    in which case it is given by hi = max(e*ldexp(1, (exponent(xi)), e)
+    where  e = ldexp(T(1), exponent(epsi)) that insures that the denominator of the quotient
+    is a power of 2 and can help gain some more correct digits on the result.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+
+    @return an expression which will eventually evaluates to the derivative
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::gillmurray_, gillmurray, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::gillmurray_, gillmurray, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::gillmurray_, gillmurray, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::gillmurray_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+
+} }
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/gradient.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/gradient.hpp
@@ -1,0 +1,113 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_GRADIENT_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_GRADIENT_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief gradient generic tag
+
+     Represents the gradient function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct gradient_ : ext::unspecified_<gradient_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<gradient_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_gradient_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::gradient_, Site>
+   dispatching_gradient_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::gradient_, Site>();
+   }
+   template<class... Args>
+   struct impl_gradient_;
+  }
+  /*!
+    Computes the numerical approximation first order derivatives of a function f
+    from \f$R^n$\f to \f$K$\f (where \f$K\f$ is \f$R\f$ or \f$C\f$),  using
+     forward,  backward,  centered or vand (very acurate numerical derivative method).
+
+    vand is reserved to real functions (\f$K\f$ is \f$R\f$) that can be nonetheless evaluated
+    for complex inputs (this method is insensitive to epsi and pow2den_ parameters) ;
+
+    The returned value is a matrix each column of which contains the  partial
+    f derivatives computed on the respective column of the entry.
+
+    @par Semantic:
+
+    For every functor f and matrix expresion x of floating type T elements
+
+    @code
+    gradientdx = gradient(f, x,  method{, epsi}{,  pow2den_});
+    @endcode
+
+    is respectively equivalent to
+
+    @code
+    gradientdx = (f(x+h)-f(x-h))/(2*h); if method is nt2::tag::centered_
+    gradientdx = (f(x+h)-f(x))/h;       if method is nt2::tag::forward_
+    gradientdx = (f(x)-f(x-h))/h;       if method is nt2::tag::backward_
+    gradientdx = imag(f(x)/Eps<T>());   if method is nt2::tag::vand_
+    @endcode
+
+    h is computed automatically using the inputs and Derivinc constant.
+    If you want more control on epsi use one of @funcref{forward}, @funcref{backward},
+    @funcref{centered} functors or/and the pow2den_ parameter.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}, @funcref{vand}, @funcref{Derivinc}, @funcref{gradient}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+    @param method used in numerical numerical_derivatives
+    @param pow2den_  try enhancing precision by computing a h value that is a power of 2.
+
+    @return the derivative value
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::gradient_, gradient, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::gradient_, gradient, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::gradient_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/hessian.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/hessian.hpp
@@ -1,0 +1,112 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_HESSIAN_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_HESSIAN_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief hessian generic tag
+
+     Represents the hessian function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct hessian_ : ext::unspecified_<hessian_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<hessian_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_hessian_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::hessian_, Site>
+   dispatching_hessian_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::hessian_, Site>();
+   }
+   template<class... Args>
+   struct impl_hessian_;
+  }
+  /*!
+    Computes the hessian  (second order derivative) numerical derivative .
+
+    @par Semantic:
+
+    For every functor f from Rn (height(x)) to Rm  and  matrix expression x of size nxp
+    of floating elements of type T will produce a matrix expression of size mxnxp (
+    one line by f-component (m), one colon by x colon vector component (n), one page by x colon (p)
+
+    It computes only the onal of the hessian matrix at each point as columns vectors of a matrix result.
+
+    @code
+    dfdx = hessian(f, x);
+    @endcode
+
+    is equivalent to
+
+    @code
+    for (i = 1, i <= n, ++i)
+      for (j = 1, i <= m, ++j)
+      {
+        x(j, _) = x(j, _) + I<type_t>()*Eps<type_t>();
+        d2fdx2(_, j, _) = (2*f(x)-real(f(x)))/Eps<T>();
+        x(j, _) = real( x(j, _));
+      }
+    @endcode
+
+    f is supposed real for real entries and also computable for complex entries.
+    Also  x is a matrix each colon is supposed to be an f entry and f must be able
+    to produce a matrix of mxn outputs for each colon of x.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+
+    @return an expression which will eventually evaluates to the derivative
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::hessian_, hessian, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::hessian_, hessian, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::hessian_, hessian, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::hessian_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+
+} }
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/hessiandiag.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/hessiandiag.hpp
@@ -1,0 +1,127 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_HESSIANDIAG_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_HESSIANDIAG_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief hessiandiag generic tag
+
+     Represents the hessiandiag function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct hessiandiag_ : ext::unspecified_<hessiandiag_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<hessiandiag_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_hessiandiag_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::hessiandiag_, Site>
+   dispatching_hessiandiag_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::hessiandiag_, Site>();
+   }
+   template<class... Args>
+   struct impl_hessiandiag_;
+  }
+  /*!
+    Computes the hessiandiag very accurate second order derivative numerical derivative .
+
+    @par Semantic:
+
+    For every functor f from Rn (height(x)) to Rm  and  matrix expression x of size nxp
+    of floating elements of type T will produce a matrix expression of size mxnxp (
+    one line by f-component (m), one colon by x colon vector component (n), one page by x colon (p)
+
+    It computes only the diagonal of the hessian matrix at each point as columns vectors of a matrix result.
+
+    @code
+    dfdx = hessiandiag(f, x);
+    @endcode
+
+    is equivalent to
+
+    @code
+    for (i = 1, i <= n, ++i)
+      for (j = 1, i <= m, ++j)
+      {
+        x(j, _) = x(j, _) + I<type_t>()*Eps<type_t>();
+        d2fdx2(_, j, _) = (2*f(x)-real(f(x)))/Eps<T>();
+        x(j, _) = real( x(j, _));
+      }
+    @endcode
+
+    f is supposed real for real entries and also computable for complex entries.
+    Also  x is a matrix each colon is supposed to be an f entry and f must be able
+    to produce a matrix of mxn outputs for each colon of x.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+
+    @return an expression which will eventually evaluates to the derivative
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::hessiandiag_, hessiandiag, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::hessiandiag_, hessiandiag, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::hessiandiag_, hessiandiag, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::hessiandiag_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+
+//   /// INTERNAL ONLY
+//   template<class Domain, int N, class Expr>
+//   struct  value_type<nt2::tag::blkdiag_,Domain,N,Expr>
+//   {
+//     typedef typename  boost::proto::result_of
+//                     ::child_c<Expr&,0>::value_type::value_type  type;
+//     typedef typename  boost::proto::result_of
+//                     ::child_c<Expr&,1>::value_type::value_type  other_type;
+
+//     BOOST_MPL_ASSERT_MSG
+//     ( (boost::is_same<type,other_type>::value)
+//     , NT2_INCOMPATIBLE_TYPE_IN_BLKDIAG_EXPRESSION
+//     , (type,other_type)
+//     );
+//   };
+} }
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/backward.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/backward.hpp
@@ -1,0 +1,107 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_BACKWARD_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_BACKWARD_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/backward.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/max.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/fast_ldexp.hpp>
+#include <nt2/include/functions/exponent.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <utility>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( backward_, tag::cpu_
+                            , (F)(X)(EPSI)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& epsi) const
+    {
+      rtype_t h = max(epsi*abs(x), epsi);
+      return (f(x)-f(x-h))/h;
+    }
+  };
+
+
+   BOOST_DISPATCH_IMPLEMENT  ( backward_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x) const
+    {
+      return backward(f, x, Derivinc<rtype_t>());
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( backward_, tag::cpu_
+                            , (F)(X)(EPSI)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x, const EPSI& epsi
+                          , const POW2DEN&) const
+    {
+      rtype_t  e = fast_ldexp(One<rtype_t>(), exponent(epsi));
+      rtype_t  h = max(e*fast_ldexp(One<rtype_t>(), exponent(x)), e);
+      return  (f(x)-f(x-h))/h;
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( backward_, tag::cpu_
+                            , (F)(X)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x
+                          ,  const POW2DEN&) const
+    {
+      X  h = max(Derivinc<rtype_t>()*fast_ldexp(One<rtype_t>(), exponent(x))
+                          , Derivinc<rtype_t>());
+      return  (f(x)-f(x-h))/h;
+
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/centered.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/centered.hpp
@@ -1,0 +1,105 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_CENTERED_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_CENTERED_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/centered.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/max.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/fast_ldexp.hpp>
+#include <nt2/include/functions/exponent.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <utility>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( centered_, tag::cpu_
+                            , (F)(X)(EPSI)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& epsi) const
+    {
+      rtype_t h = max(epsi*abs(x), epsi);
+      return (f(x+h)-f(x-h))/(h+h);
+    }
+  };
+
+
+   BOOST_DISPATCH_IMPLEMENT  ( centered_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x) const
+    {
+      return centered(f, x, Derivinc<rtype_t>());
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( centered_, tag::cpu_
+                            , (F)(X)(EPSI)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x, const EPSI& epsi
+                          , const POW2DEN&) const
+    {
+      rtype_t e = fast_ldexp(One<rtype_t>(), exponent(epsi));
+      rtype_t h = max(e*fast_ldexp(One<rtype_t>(), exponent(x)), e);
+      return  (f(x+h)-f(x-h))/(h+h);
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( centered_, tag::cpu_
+                            , (F)(X)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x,  const POW2DEN&) const
+    {
+      rtype_t h = max(Derivinc<rtype_t>()*fast_ldexp(One<rtype_t>(), exponent(x))
+                          , Derivinc<rtype_t>());
+      return  (f(x+h)-f(x-h))/(h+h);
+
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/d2f.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/d2f.hpp
@@ -1,0 +1,103 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_D2F_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_D2F_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/d2f.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/exponent.hpp>
+#include <nt2/include/functions/fast_ldexp.hpp>
+#include <nt2/include/functions/fma.hpp>
+#include <nt2/include/functions/max.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/sqr.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/mtwo.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( d2f_, tag::cpu_
+                            , (F)(X)(EPSI)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                            )
+  {
+    typedef X result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& epsi) const
+    {
+      result_type  h = max(epsi*abs(x), epsi);
+      return  (f(x)*Mtwo<X>()+f(x+h)+f(x-h))/(sqr(h));
+    }
+  };
+
+
+   BOOST_DISPATCH_IMPLEMENT  ( d2f_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef X result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x) const
+    {
+      return d2f(f, x, Derivinc2<result_type>());
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( d2f_, tag::cpu_
+                            , (F)(X)(EPSI)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef X result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x, const EPSI& epsi
+                          , const POW2DEN&) const
+    {
+      result_type  e = fast_ldexp(One<result_type>(), exponent(epsi));
+      result_type  h = max(e*fast_ldexp(One<result_type>(), exponent(x)), e);
+      return (f(x)*Mtwo<X>()+ f(x+h)+f(x-h))/(sqr(h));
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( d2f_, tag::cpu_
+                            , (F)(X)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef X result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x,  const POW2DEN&) const
+    {
+      result_type  h = max(Derivinc2<result_type>()*fast_ldexp(One<result_type>(), exponent(x))
+                          , Derivinc2<result_type>());
+      return  (f(x)*Mtwo<X>()+f(x+h)+f(x-h))/(sqr(h));
+
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/df.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/df.hpp
@@ -1,0 +1,70 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_DF_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_DF_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/df.hpp>
+#include <nt2/include/functions/backward.hpp>
+#include <nt2/include/functions/centered.hpp>
+#include <nt2/include/functions/forward.hpp>
+#include <nt2/include/functions/vand.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <utility>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/if.hpp>
+#include <nt2/sdk/meta/as_real.hpp>
+
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( df_, tag::cpu_
+                            , (F)(X)(M)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<M>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) v_type;
+    typedef typename meta::as_real<v_type>::type           r_type;
+    typedef typename boost::mpl::if_<boost::is_same<M, nt2::policy<tag::vand_>>
+                                     , r_type
+                                     , v_type>::type result_type;
+
+    typedef typename M::option_type                     method_t;
+    BOOST_FORCEINLINE
+    result_type operator()(const F &f, const X& x, const M& ) const
+    {
+      NT2_DISPLAY(type_id< method_t>());
+      return functor<method_t>()(f, x);
+    }
+  };
+  BOOST_DISPATCH_IMPLEMENT  ( df_, tag::cpu_
+                            , (F)(X)(M)(P)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<M>)
+                              (unspecified_<P>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) v_type;
+    typedef typename meta::as_real<v_type>::type           r_type;
+    typedef typename boost::mpl::if_<boost::is_same<M, tag::vand_>
+                                     , r_type
+                                     , v_type>::type result_type;
+    typedef typename M::option_type                     method_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F &f, const X& x, const M& , const P& ) const
+    {
+      return functor<method_t>()(f, x, P());
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/forward.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/forward.hpp
@@ -1,0 +1,106 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_FORWARD_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_FORWARD_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/forward.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/max.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/fast_ldexp.hpp>
+#include <nt2/include/functions/exponent.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <utility>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( forward_, tag::cpu_
+                            , (F)(X)(EPSI)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& epsi) const
+    {
+      rtype_t h = max(epsi*abs(x), epsi);
+      return (f(x+h)-f(x))/h;
+    }
+  };
+
+
+   BOOST_DISPATCH_IMPLEMENT  ( forward_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x) const
+    {
+      return forward(f, x, Derivinc<rtype_t>());
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( forward_, tag::cpu_
+                            , (F)(X)(EPSI)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x, const EPSI& epsi
+                          , const POW2DEN&) const
+    {
+      rtype_t e = fast_ldexp(One<rtype_t>(), exponent(epsi));
+      rtype_t h = max(e*fast_ldexp(One<rtype_t>(), exponent(x)), e);
+      return  (f(x+h)-f(x))/h;
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( forward_, tag::cpu_
+                            , (F)(X)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x
+                          ,  const POW2DEN&) const
+    {
+      rtype_t h = max(Derivinc<rtype_t>()*fast_ldexp(One<rtype_t>(), exponent(x))
+                          , Derivinc<rtype_t>());
+      return  (f(x+h)-f(x))/h;
+
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/gillmurray.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/gillmurray.hpp
@@ -1,0 +1,106 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_GILLMURRAY_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_GILLMURRAY_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/gillmurray.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/max.hpp>
+#include <nt2/include/functions/minus.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/fast_ldexp.hpp>
+#include <nt2/include/functions/exponent.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <utility>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( gillmurray_, tag::cpu_
+                            , (F)(X)(EPSI)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& epsi) const
+    {
+      rtype_t h = max(epsi*abs(x), epsi);
+      return (f(x+h)-Two<result_type>()*f(x)+f(x-h))/sqr(h);
+    }
+  };
+
+
+   BOOST_DISPATCH_IMPLEMENT  ( gillmurray_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x) const
+    {
+      return gillmurray(f, x, Derivinc2<rtype_t>());
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( gillmurray_, tag::cpu_
+                            , (F)(X)(EPSI)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x, const EPSI& epsi
+                          , const POW2DEN&) const
+    {
+      rtype_t e = fast_ldexp(One<rtype_t>(), exponent(epsi));
+      rtype_t h = max(e*fast_ldexp(One<rtype_t>(), exponent(x)), e);
+      return (f(x+h)-Two<result_type>()*f(x)+f(x-h))/sqr(h);
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( gillmurray_, tag::cpu_
+                            , (F)(X)(POW2DEN)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<POW2DEN>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) result_type;
+    typedef typename meta::as_real<X>::type                    rtype_t;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F& f, const X& x
+                          ,  const POW2DEN&) const
+    {
+      rtype_t h = max(Derivinc2<rtype_t>()*fast_ldexp(One<rtype_t>(), exponent(x))
+                          , Derivinc2<rtype_t>());
+      return (f(x+h)-Two<result_type>()*f(x)+f(x-h))/sqr(h);
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/gradient.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/gradient.hpp
@@ -1,0 +1,77 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_GRADIENT_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_GRADIENT_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/gradient.hpp>
+#include <nt2/include/functions/backward.hpp>
+#include <nt2/include/functions/centered.hpp>
+#include <nt2/include/functions/forward.hpp>
+#include <nt2/include/functions/vand.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <utility>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/if.hpp>
+#include <nt2/sdk/meta/as_real.hpp>
+
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( gradient_, tag::cpu_
+                            , (F)(X)(M)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<M>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) v_type;
+    typedef typename meta::as_real<v_type>::type           r_type;
+    typedef typename boost::mpl::if_<boost::is_same<M, tag::vand_>
+                                     , r_type
+                                     , v_type>::type result_type;
+    BOOST_FORCEINLINE
+    result_type operator()(const F &f, const X& x, const M& ) const
+    {
+      return functor<M>()(f, x);
+    }
+  };
+  BOOST_DISPATCH_IMPLEMENT  ( gradient_, tag::cpu_
+                            , (F)(X)(M)(P)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<M>)
+                              (unspecified_<P>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>())) v_type;
+    typedef typename meta::as_real<v_type>::type           r_type;
+    typedef typename boost::mpl::if_<boost::is_same<M, tag::vand_>
+                                     , r_type
+                                     , v_type>::type result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const F &f, const X& x, const M& , const P& ) const
+    {
+      return compute(f, x, M(), P());
+    }
+  private :
+    static BOOST_FORCEINLINE result_type compute(const F &f, const X & x
+                                                , const M&, const P&)
+    {
+      return functor<M>()(f, x, P());
+    }
+    static BOOST_FORCEINLINE result_type compute(const F &f, const X & x
+                                                , const tag::vand_&, const P&)
+    {
+      return functor<M>()(f, x);
+    }
+  };
+
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/vand.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/vand.hpp
@@ -1,0 +1,81 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_VAND_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_VAND_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/vand.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/imag.hpp>
+#include <nt2/include/functions/mul_minus_i.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/eps.hpp>
+#include <nt2/include/constants/inveps.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( vand_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>()))         v_type;
+    typedef typename meta::as_real<v_type>::type              result_type;
+    // f must C->C but f|R R -> R
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x) const
+    {
+      return imag(f(tocomplex(x, Eps<result_type>())))/Eps<result_type>();
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( vand_, tag::cpu_
+                            , (F)(X)(EPSI)(DUMMY)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI>>)
+                              (unspecified_<DUMMY>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>()))         v_type;
+    typedef typename meta::as_real<v_type>::type              result_type;
+    // f must C->C but f|R R -> R
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& ,  const DUMMY &) const
+    {
+      return imag(f(tocomplex(x, Eps<result_type>())))*Inveps<result_type>();
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( vand_, tag::cpu_
+                            , (F)(X)(DUMMY)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<DUMMY>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>()))         v_type;
+    typedef typename meta::as_real<v_type>::type              result_type;
+    // f must C->C but f|R R -> R
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x,  const DUMMY &) const
+    {
+      return imag(f(tocomplex(x, Eps<result_type>())))*Inveps<result_type>();
+    }
+  };
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/vand2.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/scalar/vand2.hpp
@@ -1,0 +1,81 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_VAND2_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_SCALAR_VAND2_HPP_INCLUDED
+
+#include <nt2/numerical_derivatives/functions/vand2.hpp>
+#include <nt2/include/functions/abs.hpp>
+#include <nt2/include/functions/divides.hpp>
+#include <nt2/include/functions/multiplies.hpp>
+#include <nt2/include/functions/plus.hpp>
+#include <nt2/include/functions/imag.hpp>
+#include <nt2/include/functions/mul_minus_i.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/constants/one.hpp>
+#include <nt2/include/constants/eps.hpp>
+#include <nt2/include/constants/inveps2.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+
+namespace nt2 { namespace ext
+{
+  BOOST_DISPATCH_IMPLEMENT  ( vand2_, tag::cpu_
+                            , (F)(X)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>()))         v_type;
+    typedef typename meta::as_real<v_type>::type              result_type;
+    // f must C->C but f|R R -> R
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x) const
+    {
+      return Two<result_type>()*(real(f(tocomplex(x,Eps<result_type>())))-real(f(x)))*Inveps2<result_type>();
+    }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( vand2_, tag::cpu_
+                            , (F)(X)(EPSI)(DUMMY)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (scalar_<floating_<EPSI>>)
+                              (unspecified_<DUMMY>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>()))         v_type;
+    typedef typename meta::as_real<v_type>::type              result_type;
+    // f must C->C but f|R R -> R
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x, const EPSI& ,  const DUMMY &) const
+    {
+      return Two<result_type>()*(real(f(tocomplex(x,Eps<result_type>()))-real(f(x))))*Inveps2<result_type>();
+                                 }
+  };
+
+  BOOST_DISPATCH_IMPLEMENT  ( vand2_, tag::cpu_
+                            , (F)(X)(DUMMY)
+                            , (unspecified_<F>)
+                              (scalar_<floating_<X> >)
+                              (unspecified_<DUMMY>)
+                            )
+  {
+    typedef decltype(std::declval<F>()(std::declval<X>()))         v_type;
+    typedef typename meta::as_real<v_type>::type              result_type;
+    // f must C->C but f|R R -> R
+
+    BOOST_FORCEINLINE
+    result_type operator()(F f, const X& x,  const DUMMY &) const
+    {
+      return Two<result_type>()*(real(f(tocomplex(x,Eps<result_type>())))-real(f(x)))*Inveps2<result_type>();
+    }
+  };
+} }
+
+#endif

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/vand.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/vand.hpp
@@ -1,0 +1,110 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_VAND_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_VAND_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief vand generic tag
+
+     Represents the vand function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct vand_ : ext::unspecified_<vand_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<vand_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_vand_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::vand_, Site>
+   dispatching_vand_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::vand_, Site>();
+   }
+   template<class... Args>
+   struct impl_vand_;
+  }
+  /*!
+    Computes the vand very accurate numerical derivative scheme to evaluate a derivative.
+    If applicable the scheme gives a quasi perfect value of the derivative to a few ulps.
+
+    @par Semantic:
+
+    For every functor f from Rn (height(x)) to Rm  and  matrix expression x of size nxp
+    of floating elements of type T will produce a matrix expression of size mxnxp (
+    one line by f-component (m), one colon by x colon vector component (n), one page by x colon (p)
+
+    @code
+    dfdx = vand(f, x);
+    @endcode
+
+    is equivalent to
+
+    @code
+    for (i = 1, i <= n, ++i)
+      for (j = 1, i <= m, ++j)
+      {
+        x(j, _) = x(j, _) + I<type_t>()*Eps<type_t>();
+        dfdx(_, j, _) = imag(f(x)/Eps<T>());
+        x(j, _) = real( x(j, _));
+      }
+    @endcode
+
+    f is supposed real for real entries and also computable for complex entries.
+    Also  x is a matrix each colon is supposed to be an f entry and f must be able
+    to produce a matrix of mxn outputs for each colon of x.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+
+    @return an expression which will eventually evaluates to the derivative
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::vand_, vand, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::vand_, vand, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::vand_, vand, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::vand_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+} }
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/vand2.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/functions/vand2.hpp
@@ -1,0 +1,126 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_VAND2_HPP_INCLUDED
+#define NT2_NUMERICAL_DERIVATIVES_FUNCTIONS_VAND2_HPP_INCLUDED
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+
+
+namespace nt2 { namespace tag
+  {
+   /*!
+     @brief vand2 generic tag
+
+     Represents the vand2 function in generic contexts.
+
+     @par Models:
+        Hierarchy
+   **/
+    struct vand2_ : ext::unspecified_<vand2_>
+    {
+      /// @brief Parent hierarchy
+      typedef ext::unspecified_<vand2_> parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY(
+        dispatching_vand2_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+   template<class Site>
+   BOOST_FORCEINLINE generic_dispatcher<tag::vand2_, Site>
+   dispatching_vand2_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+   {
+     return generic_dispatcher<tag::vand2_, Site>();
+   }
+   template<class... Args>
+   struct impl_vand2_;
+  }
+  /*!
+    Computes the vand2 very accurate second order derivative numerical derivative .
+
+    @par Semantic:
+
+    For every functor f from Rn (height(x)) to Rm  and  matrix expression x of size nxp
+    of floating elements of type T will produce a matrix expression of size mxnxp (
+    one line by f-component (m), one colon by x colon vector component (n), one page by x colon (p)
+
+    @code
+    dfdx = vand2(f, x);
+    @endcode
+
+    is equivalent to
+
+    @code
+    x0 = x;
+    for (i = 1, i <= n, ++i)
+      for (j = 1, i <= m, ++j)
+      {
+        x(j, _) = x(j, _) + I<type_t>()*Eps<type_t>();
+        d2fdx2(_, j, _) = (2*f(x)-real(f(x0)))/Eps<T>();
+        x(j, _) = real( x(j, _));
+      }
+    @endcode
+
+    f is supposed real for real entries and also computable for complex entries.
+    Also  x is a matrix each colon is supposed to be an f entry and f must be able
+    to produce a matrix of mxn outputs for each colon of x.
+
+    @see @funcref{forward}, @funcref{backward}, @funcref{centered}
+    @param f function to derivate
+    @param x points of numerical_derivatives
+
+    @return an expression which will eventually evaluates to the derivative
+  **/
+  NT2_FUNCTION_IMPLEMENTATION(tag::vand2_, vand2, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::vand2_, vand2, 3)
+  NT2_FUNCTION_IMPLEMENTATION(tag::vand2_, vand2, 4)
+}
+
+namespace nt2 { namespace ext
+{
+  /// INTERNAL ONLY
+  template<class Domain, int N, class Expr>
+  struct  size_of<nt2::tag::vand2_,Domain,N,Expr>
+  {
+    // TODO: case for dual static of_size_
+    typedef _2D result_type;
+
+    BOOST_FORCEINLINE result_type operator ()(Expr& e) const
+    {
+      result_type sizee;
+      sizee[0] = 1; //+= boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+      sizee[1] = boost::fusion::at_c<0>(boost::proto::child_c<1>(e).extent());
+
+      return sizee;
+    }
+
+  };
+
+//   /// INTERNAL ONLY
+//   template<class Domain, int N, class Expr>
+//   struct  value_type<nt2::tag::blkdiag_,Domain,N,Expr>
+//   {
+//     typedef typename  boost::proto::result_of
+//                     ::child_c<Expr&,0>::value_type::value_type  type;
+//     typedef typename  boost::proto::result_of
+//                     ::child_c<Expr&,1>::value_type::value_type  other_type;
+
+//     BOOST_MPL_ASSERT_MSG
+//     ( (boost::is_same<type,other_type>::value)
+//     , NT2_INCOMPATIBLE_TYPE_IN_BLKDIAG_EXPRESSION
+//     , (type,other_type)
+//     );
+//   };
+} }
+
+#endif
+

--- a/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/options.hpp
+++ b/modules/core/numerical_derivatives/include/nt2/numerical_derivatives/options.hpp
@@ -1,0 +1,39 @@
+//==============================================================================
+//         Copyright 2015          J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_OPTIONS_HPP_INCLUDED
+#define NT2_LINALG_OPTIONS_HPP_INCLUDED
+
+#include <nt2/core/options.hpp>
+#include <nt2/sdk/meta/policy.hpp>
+#include <nt2/include/functions/forward.hpp>
+#include <nt2/include/functions/backward.hpp>
+#include <nt2/include/functions/centered.hpp>
+#include <nt2/include/functions/vand.hpp>
+
+namespace nt2
+{
+  namespace ext
+  {
+//     struct forward_    : boost::mpl::true_  {}; //used in deriv, jac
+//     struct backward_   : boost::mpl::true_  {}; //used in deriv, jac
+//     struct centered_   : boost::mpl::true_  {}; //used in deriv, jac
+    struct pow2den_    : boost::mpl::true_  {}; //used in forward,  bacward, centered, deriv, jac
+    struct absolute_   : boost::mpl::true_  {}; //used in forward,  bacward, centered, deriv, jac
+    struct relative_   : boost::mpl::true_  {}; //used in forward,  bacward, centered, deriv, jac
+  }
+
+  nt2::policy<nt2::tag::forward_>      const forward_;
+  nt2::policy<nt2::tag::backward_>     const backward_;
+  nt2::policy<nt2::tag::centered_>     const centered_;
+  nt2::policy<nt2::tag::vand_>         const vand_;
+  nt2::policy<ext::pow2den_>           const pow2den_;
+  nt2::policy<ext::absolute_>          const absolute_;
+  nt2::policy<ext::relative_>          const relative_;
+ }
+
+#endif

--- a/modules/core/numerical_derivatives/src/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+################################################################################
+#         Copyright 2003 & onward LASMEA UMR 6602 CNRS/Univ. Clermont II
+#         Copyright 2009 & onward LRI    UMR 8623 CNRS/Univ Paris Sud XI
+#
+#          Distributed under the Boost Software License, Version 1.0.
+#                 See accompanying file LICENSE.txt or copy at
+#                     http://www.boost.org/LICENSE_1_0.txt
+################################################################################
+
+include(NT2Module)
+nt2_module_source_setup(core.numerical_derivatives)
+nt2_module_configure_toolbox(numerical_derivatives 1)

--- a/modules/core/numerical_derivatives/unit/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/unit/CMakeLists.txt
@@ -1,0 +1,13 @@
+##############################################################################
+###   Copyright 2015  J.T. Lapreste
+###
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+nt2_module_use_modules(test.unit)
+ADD_SUBDIRECTORY(scalar)
+ADD_SUBDIRECTORY(table)
+

--- a/modules/core/numerical_derivatives/unit/scalar/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/unit/scalar/CMakeLists.txt
@@ -1,0 +1,20 @@
+##############################################################################
+###          Copyright 2015 J.T. Lapreste
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+SET( SOURCES
+  backward.cpp
+  df.cpp
+  d2f.cpp
+  forward.cpp
+  gillmurray.cpp
+  centered.cpp
+  vand.cpp
+# List of scalar test files for toolbox numerical_derivatives
+   )
+
+nt2_module_add_tests(core.numerical_derivatives.scalar.unit ${SOURCES})

--- a/modules/core/numerical_derivatives/unit/scalar/backward.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/backward.cpp
@@ -1,0 +1,96 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/backward.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/complexify.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+
+NT2_TEST_CASE_TPL ( backward, NT2_REAL_TYPES)
+{
+  using nt2::backward;
+  using nt2::tag::backward_;
+  auto f =  [](T t){return t*t;};
+  T x =  T(nt2::Pi<T>());
+  T r = T(2)*nt2::Pi<T>();
+  T dfdx =  backward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = nt2::Invpi<T>();
+  r = 2*x;
+  dfdx =  backward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+NT2_TEST_CASE_TPL ( backwardrc, NT2_REAL_TYPES)
+{
+  using nt2::backward;
+  using nt2::tag::backward_;
+  typedef typename std::complex<T> cT;
+  auto f =  [](T t)->cT{return cT(t*t, T(1));};
+  T x =  T(nt2::Pi<T>());
+  cT r = T(2)*nt2::Pi<T>();
+
+  cT dfdx =  backward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = nt2::Invpi<T>();
+  r = T(2)*x;
+  dfdx =  backward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  backward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }

--- a/modules/core/numerical_derivatives/unit/scalar/centered.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/centered.cpp
@@ -1,0 +1,92 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/centered.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+NT2_TEST_CASE_TPL ( centered, NT2_REAL_TYPES)
+{
+  using nt2::centered;
+  using nt2::tag::centered_;
+  auto f =  [](T t){return t*t;};
+  T x =  T(nt2::Pi<T>());
+  T r = T(2)*nt2::Pi<T>();
+  T dfdx =  centered(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = nt2::Invpi<T>();
+  r = 2*x;
+  dfdx =  centered(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+NT2_TEST_CASE_TPL ( centeredrc, NT2_REAL_TYPES)
+{
+  using nt2::centered;
+  using nt2::tag::centered_;
+  typedef typename std::complex<T> cT;
+  auto f =  [](T t)->cT{return cT(t*t, T(1));};
+  T x =  T(nt2::Pi<T>());
+  cT r = T(2)*nt2::Pi<T>();
+
+  cT dfdx =  centered(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = nt2::Invpi<T>();
+  r = T(2)*x;
+  dfdx =  centered(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  centered(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }

--- a/modules/core/numerical_derivatives/unit/scalar/d2f.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/d2f.cpp
@@ -1,0 +1,59 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/d2f.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/exp.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+NT2_TEST_CASE_TPL ( d2f, NT2_REAL_TYPES)
+{
+  using nt2::d2f;
+  using nt2::tag::d2f_;
+  auto f =  [](T t){return exp(t);};
+  T x =  T(0);
+  T r = T(1);
+  T d2fdx2 =  d2f(f, x,  nt2::Derivinc2<T>());
+  NT2_TEST_ULP_EQUAL(d2fdx2, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  d2fdx2 =  d2f(f, x,  nt2::Derivinc2<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  d2fdx2 =  d2f(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  d2fdx2 =  d2f(f, x);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = T(1);
+  r = exp(x);
+  d2fdx2 =  d2f(f, x,  nt2::Derivinc2<T>());
+  NT2_TEST_ULP_EQUAL(d2fdx2, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  d2fdx2 =  d2f(f, x,  nt2::Derivinc2<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  d2fdx2 =  d2f(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  d2fdx2 =  d2f(f, x);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+

--- a/modules/core/numerical_derivatives/unit/scalar/df.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/df.cpp
@@ -1,0 +1,59 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/df.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/exp.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+NT2_TEST_CASE_TPL ( df, NT2_REAL_TYPES)
+{
+  using nt2::df;
+  using nt2::tag::df_;
+  auto f =  [](T t){return exp(t);};
+  T x =  T(0);
+  T r = T(1);
+  T dfdx =  df(f, x, nt2::forward_);
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  df(f, x,  nt2::backward_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  df(f, x,  nt2::backward_, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  df(f, x,  nt2::centered_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = T(1);
+  r = exp(x);
+  dfdx =  df(f, x,  nt2::centered_);
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  df(f, x,  nt2::centered_, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  df(f, x, nt2::forward_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  df(f, x,  nt2::backward_);
+ NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+

--- a/modules/core/numerical_derivatives/unit/scalar/forward.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/forward.cpp
@@ -1,0 +1,94 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/forward.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( forward, NT2_REAL_TYPES)
+{
+  using nt2::forward;
+  using nt2::tag::forward_;
+  auto f =  [](T t){return t*t;};
+  T x =  T(nt2::Pi<T>());
+  T r = T(2)*nt2::Pi<T>();
+  T dfdx =  forward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = nt2::Invpi<T>();
+  r = 2*x;
+  dfdx =  forward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+NT2_TEST_CASE_TPL ( forwardrc, NT2_REAL_TYPES)
+{
+  using nt2::forward;
+  using nt2::tag::forward_;
+  typedef typename std::complex<T> cT;
+  auto f =  [](T t)->cT{return cT(t*t, T(1));};
+  T x =  T(nt2::Pi<T>());
+  cT r = T(2)*nt2::Pi<T>();
+
+  cT dfdx =  forward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  x = nt2::Invpi<T>();
+  r = T(2)*x;
+  dfdx =  forward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r,  nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x,  nt2::Derivinc<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+
+  dfdx =  forward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }

--- a/modules/core/numerical_derivatives/unit/scalar/gillmurray.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/gillmurray.cpp
@@ -1,0 +1,61 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/gillmurray.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/exp.hpp>
+#include <nt2/include/functions/pow.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+NT2_TEST_CASE_TPL ( gillmurray, NT2_REAL_TYPES)
+{
+  using nt2::gillmurray;
+  using nt2::tag::gillmurray_;
+  auto f =  [](T t){return exp(t);};
+  T x =  T(0);
+  T r = T(1);
+  T ulp =  nt2::pow(nt2::Eps<T>(), T(-2.0/3.0));
+  T d2fdx2 =  gillmurray(f, x,  nt2::Derivinc2<T>());
+  NT2_TEST_ULP_EQUAL(d2fdx2, r,  ulp);
+
+  d2fdx2 =  gillmurray(f, x,  nt2::Derivinc2<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, ulp);
+
+  d2fdx2 =  gillmurray(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, ulp);
+
+  d2fdx2 =  gillmurray(f, x);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, ulp);
+
+  x = T(1);
+  r = exp(x);
+  d2fdx2 =  gillmurray(f, x,  nt2::Derivinc2<T>());
+  NT2_TEST_ULP_EQUAL(d2fdx2, r,  ulp);
+
+  d2fdx2 =  gillmurray(f, x,  nt2::Derivinc2<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, ulp);
+
+  d2fdx2 =  gillmurray(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, ulp);
+
+  d2fdx2 =  gillmurray(f, x);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, ulp);
+ }
+

--- a/modules/core/numerical_derivatives/unit/scalar/vand.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/vand.cpp
@@ -1,0 +1,44 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/vand.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/sdk/complex/meta/as_complex.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( vand, NT2_REAL_TYPES)
+{
+  using nt2::vand;
+  using nt2::tag::vand_;
+  typedef typename nt2::meta::as_complex<T>::type cT;
+  auto f =  [](cT t){return t*t;};
+  T x =  T(nt2::Pi<T>());
+  T r = T(2)*nt2::Pi<T>();
+  T dfdx =  vand(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, 0.5);
+
+
+  x = nt2::Invpi<T>();
+  r = 2*x;
+  dfdx =  vand(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r,  0.5);
+ }
+

--- a/modules/core/numerical_derivatives/unit/scalar/vand2.cpp
+++ b/modules/core/numerical_derivatives/unit/scalar/vand2.cpp
@@ -1,0 +1,34 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/vand2.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/exp.hpp>
+
+
+NT2_TEST_CASE_TPL ( vand, NT2_REAL_TYPES)
+{
+  using nt2::vand2;
+  using nt2::tag::vand2_;
+  typedef typename nt2::meta::as_complex<T>::type cT;
+  auto f =  [](cT t){return nt2::exp(t);};
+  T x = T(0);
+  T r = T(1);
+  T d2fdx2 =  vand2(f, x);
+  NT2_TEST_ULP_EQUAL(d2fdx2, r, 0.5);
+}
+

--- a/modules/core/numerical_derivatives/unit/table/CMakeLists.txt
+++ b/modules/core/numerical_derivatives/unit/table/CMakeLists.txt
@@ -1,0 +1,21 @@
+##############################################################################
+###          Copyright 2015 J.T. Lapreste
+###
+###          Distributed under the Boost Software License, Version 1.0
+###                 See accompanying file LICENSE.txt or copy at
+###                     http://www.boost.org/LICENSE_1_0.txt
+##############################################################################
+
+SET( SOURCES
+  backward.cpp
+  df.cpp
+  d2f.cpp
+  forward.cpp
+  gillmurray.cpp
+  gradient.cpp
+  centered.cpp
+  vand.cpp
+# List of table test files for toolbox numerical_derivatives
+   )
+
+nt2_module_add_tests(core.numerical_derivatives.table.unit ${SOURCES})

--- a/modules/core/numerical_derivatives/unit/table/backward.cpp
+++ b/modules/core/numerical_derivatives/unit/table/backward.cpp
@@ -1,0 +1,113 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/backward.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( backward, NT2_REAL_TYPES)
+{
+  using nt2::backward;
+  using nt2::tag::backward_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                     );
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<T> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<T> dfdx =  backward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  backward(f, x, nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  backward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+NT2_TEST_CASE_TPL ( backwardrc, NT2_REAL_TYPES)
+{
+  using nt2::backward;
+  using nt2::tag::backward_;
+
+  typedef std::complex<T> cT;
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::tocomplex(nt2::cat(1
+                               , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                               , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                               ), T(1));
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<cT> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<cT> dfdx =  backward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  backward(f, x, nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  backward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/centered.cpp
+++ b/modules/core/numerical_derivatives/unit/table/centered.cpp
@@ -1,0 +1,115 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/centered.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/derivincc.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( centered, NT2_REAL_TYPES)
+{
+  using nt2::centered;
+  using nt2::tag::centered_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                     );
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<T> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<T> dfdx =  centered(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  centered(f, x, nt2::Derivincc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  centered(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+NT2_TEST_CASE_TPL ( centeredrc, NT2_REAL_TYPES)
+{
+  using nt2::centered;
+  using nt2::tag::centered_;
+
+  typedef std::complex<T> cT;
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::tocomplex(nt2::cat(1
+                               , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                               , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                               ), T(1));
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<cT> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<cT> dfdx =  centered(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  centered(f, x, nt2::Derivincc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  centered(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/d2f.cpp
+++ b/modules/core/numerical_derivatives/unit/table/d2f.cpp
@@ -1,0 +1,71 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/d2f.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( d2f, NT2_REAL_TYPES)
+{
+  using nt2::d2f;
+  using nt2::tag::d2f_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                     );
+    };
+  auto dd2f =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2,              0,
+                          0        , 2*xx(3),
+                          0        ,      0);
+   };
+
+  nt2::table<T> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 dd2f(x(nt2::_, 1)),
+                                                 dd2f(x(nt2::_, 2))
+                                                ),
+                                        dd2f(x(nt2::_, 3))
+                                       ),
+                               dd2f(x(nt2::_, 4))
+                              );
+  nt2::table<T> dfdx =  d2f(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  d2f(f, x, nt2::Derivinc2<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  d2f(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/df.cpp
+++ b/modules/core/numerical_derivatives/unit/table/df.cpp
@@ -1,0 +1,82 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/df.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( df, NT2_REAL_TYPES)
+{
+  using nt2::df;
+  using nt2::tag::df_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                     );
+    };
+  typedef typename nt2::meta::as_complex<T>::type cT;
+  auto cf =  [](nt2::table<cT> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                     );
+    };
+
+  auto ddf =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<T> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 ddf(x(nt2::_, 1)),
+                                                 ddf(x(nt2::_, 2))
+                                                ),
+                                        ddf(x(nt2::_, 3))
+                                       ),
+                               ddf(x(nt2::_, 4))
+                              );
+  nt2::table<T> dfdx =  df(f, x, nt2::forward_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  df(f, x, nt2::centered_, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  NT2_DISPLAY(nt2::type_id(nt2::vand_));
+   dfdx = df(cf, x, nt2::vand_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/forward.cpp
+++ b/modules/core/numerical_derivatives/unit/table/forward.cpp
@@ -1,0 +1,117 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/forward.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/complexify.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/tocomplex.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/derivinc.hpp>
+#include <nt2/sdk/complex/meta/as_complex.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( forward, (double))//NT2_REAL_TYPES)
+{
+  using nt2::forward;
+  using nt2::tag::forward_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                     );
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<T> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<T> dfdx =  forward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  forward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  forward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+NT2_TEST_CASE_TPL ( forwardrc, NT2_REAL_TYPES)
+{
+  using nt2::forward;
+  using nt2::tag::forward_;
+
+  typedef std::complex<T> cT;
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return nt2::tocomplex(nt2::cat(1
+                               , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                               , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_)
+                               ), T(1));
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+   };
+
+  nt2::table<cT> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<cT> dfdx =  forward(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  forward(f, x,  nt2::Derivinc<T>());
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  dfdx =  forward(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/gillmurray.cpp
+++ b/modules/core/numerical_derivatives/unit/table/gillmurray.cpp
@@ -1,0 +1,81 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/gillmurray.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/pow.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/sqrt.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/include/constants/derivinc2.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( gillmurray, NT2_REAL_TYPES)
+{
+  using nt2::gillmurray;
+  using nt2::tag::gillmurray_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(1), T(4), 4), 4, 1); //12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return xx(1, nt2::_)*(xx(1, nt2::_)+sqr(xx(2, nt2::_)))+sqr(xx(3, nt2::_))*xx(3, nt2::_);
+    };
+  auto dd2f =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(4, 4),
+                          2,             2*xx(2),       0,   0,
+                          2*xx(2),       2*xx(1),       0,   0,
+                          0,             0,       6*xx(3),   0,
+                          0,             0,             0,   0 );
+   };
+
+//   nt2::table<T> r =   nt2::cat(3,
+//                                nt2::cat(3,
+//                                         nt2::cat(3,
+//                                                  dd2f(x(nt2::_, 1)),
+//                                                  dd2f(x(nt2::_, 2))
+//                                                  ),
+//                                         dd2f(x(nt2::_, 3))
+//                                        ),
+//                                dd2f(x(nt2::_, 4))
+//                               );
+  T ulp =  nt2::pow(nt2::Eps<T>(), T(-2.0/3.0));
+  nt2::table<T> r = dd2f(x);
+  nt2::table<T> d2fdxdy =  gillmurray(f, x);
+  NT2_DISPLAY(d2fdxdy);
+  NT2_DISPLAY(r);
+  NT2_TEST_ULP_EQUAL(d2fdxdy, r, ulp);
+  d2fdxdy =  gillmurray(f, x,  nt2::Derivincgm<T>());
+  NT2_TEST_ULP_EQUAL(d2fdxdy, r, ulp);
+  NT2_DISPLAY(d2fdxdy);
+  d2fdxdy =  gillmurray(f, x, nt2::Derivincgm<T>(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdxdy, r, ulp);
+  NT2_DISPLAY(d2fdxdy);
+  d2fdxdy =  gillmurray(f, x, nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(d2fdxdy, r, ulp);
+  NT2_DISPLAY(d2fdxdy);
+ }
+
+
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/gradient.cpp
+++ b/modules/core/numerical_derivatives/unit/table/gradient.cpp
@@ -1,0 +1,72 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/gradient.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/exp.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/functions/sqr.hpp>
+#include <nt2/include/functions/squeeze.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/include/constants/two.hpp>
+#include <nt2/include/constants/sqrteps.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( gradient, NT2_REAL_TYPES)
+{
+  using nt2::gradient;
+  using nt2::tag::gradient_;
+
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<T> xx)
+    {
+      return  xx(1, nt2::_)*(xx(1, nt2::_)+xx(2, nt2::_))+nt2::sqr(xx(3, nt2::_));
+    };
+  typedef typename nt2::meta::as_complex<T>::type cT;
+  auto cf =  [](nt2::table<cT> xx)
+    {
+      return   xx(1, nt2::_)*(xx(1, nt2::_)+xx(2, nt2::_))+nt2::sqr(xx(3, nt2::_));
+    };
+
+  auto gf =  [](nt2::table<T> xx)
+    {
+      return nt2::cat(1
+                     , nt2::Two<T>()*xx(1, nt2::_)+xx(2, nt2::_)
+                     , nt2::cat(1
+                               , xx(1, nt2::_)
+                               , nt2::Two<T>()*xx(3, nt2::_)
+                               )
+                     );
+    };
+
+  nt2::table<T> r =   gf(x);
+  nt2::table<T> gradientdx =  gradient(f, x, nt2::tag::forward_());
+  NT2_TEST_ULP_EQUAL(gradientdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  gradientdx =  gradient(f, x, nt2::tag::centered_(), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(gradientdx, r, nt2::rec(nt2::Sqrteps<T>()));
+  gradientdx =  gradient(cf, x, nt2::tag::vand_());
+  NT2_TEST_ULP_EQUAL(gradientdx, r, nt2::rec(nt2::Sqrteps<T>()));
+ }
+
+
+

--- a/modules/core/numerical_derivatives/unit/table/vand.cpp
+++ b/modules/core/numerical_derivatives/unit/table/vand.cpp
@@ -1,0 +1,71 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/numerical_derivatives/include/functions/vand.hpp>
+
+#include <nt2/sdk/functor/meta/call.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/type_expr.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <boost/simd/sdk/config.hpp>
+#include <nt2/numerical_derivatives/options.hpp>
+#include <nt2/include/functions/cat.hpp>
+#include <nt2/include/functions/cons.hpp>
+#include <nt2/include/functions/linspace.hpp>
+#include <nt2/include/functions/colvect.hpp>
+#include <nt2/include/functions/complexify.hpp>
+#include <nt2/include/functions/globalsum.hpp>
+#include <nt2/include/functions/rec.hpp>
+#include <nt2/include/constants/pi.hpp>
+#include <nt2/include/constants/invpi.hpp>
+#include <nt2/sdk/complex/meta/as_complex.hpp>
+#include <nt2/table.hpp>
+
+
+
+NT2_TEST_CASE_TPL ( vand, NT2_REAL_TYPES)
+{
+  using nt2::vand;
+  using nt2::tag::vand_;
+
+  typedef typename nt2::meta::as_complex<T>::type cT;
+  nt2::table<T> x =  nt2::reshape(nt2::linspace(T(3), T(14), 12), 3, 4);
+  auto f =  [](nt2::table<cT> xx)
+    {
+      return nt2::cat(1
+                     , xx(1, nt2::_)*xx(1, nt2::_)+xx(2, nt2::_)
+                     , xx(2, nt2::_)*xx(2, nt2::_)*xx(3, nt2::_));
+    };
+  auto df =  [](nt2::table<T> xx)
+    {
+      return nt2::cons<T>(nt2::of_size(2, 3),
+                          2*xx(1),              0,
+                          1        , 2*xx(2)*xx(3),
+                          0        , xx(2)*xx(2) );
+    };
+  nt2::table<T> r =   nt2::cat(3,
+                               nt2::cat(3,
+                                        nt2::cat(3,
+                                                 df(x(nt2::_, 1)),
+                                                 df(x(nt2::_, 2))
+                                                ),
+                                        df(x(nt2::_, 3))
+                                       ),
+                               df(x(nt2::_, 4))
+                              );
+  nt2::table<T> dfdx =  vand(f, x);
+  NT2_TEST_ULP_EQUAL(dfdx, r, 0.5);
+  dfdx =  vand(f, x, T(1));
+  NT2_TEST_ULP_EQUAL(dfdx, r, 0.5);
+  dfdx =  vand(f, x, T(1), nt2::pow2den_);
+  NT2_TEST_ULP_EQUAL(dfdx, r, 0.5);
+ }
+
+
+


### PR DESCRIPTION
his module provides implementation of functions allowing computation of numerical
derivatives, gradients, jacobians or hessians by divided-difference or complex-step if available.

Precision is poor (except for complex step)first derivatives are computed loosing half of the significant digits and second-order 3/4. New  modules to come will allow to compute the nth-derivative of most of the nt2 functors, and to compute first order derivatives of your own nt2-written functions with floating point accuracy. However these formulas can be used in corner cases  and offer useful comparisons.

